### PR TITLE
Rename Artifact fields: artifact_id→label, content_hash→artifact_id

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,16 +48,16 @@ src/synix/
 ## Key Module Interfaces
 
 **pipeline/runner.py** calls:
-- `artifacts.store.{save,load}_artifact()`, `get_content_hash()` — cache checking
+- `artifacts.store.{save,load}_artifact()`, `get_artifact_id()` — cache checking
 - `transforms.*.execute(inputs, config) -> Artifact`
 - `projections.*.materialize(artifacts, config)` — after build
-- `artifacts.provenance.record(artifact_id, parent_ids, prompt_id, model_config)`
+- `artifacts.provenance.record(label, parent_ids, prompt_id, model_config)`
 
 **cli.py** calls:
 - `pipeline.config.load(path) -> Pipeline`
 - `pipeline.runner.run(pipeline, source_dir) -> RunResult`
 - `projections.search_index.query(query, layers) -> list[SearchResult]`
-- `artifacts.provenance.get_chain(artifact_id) -> list[ProvenanceRecord]`
+- `artifacts.provenance.get_chain(label) -> list[ProvenanceRecord]`
 
 ## CLI Commands
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Browse what was built:
 ```bash
 uvx synix list                    # all artifacts, grouped by layer
 uvx synix show final-report       # render an artifact as markdown
-uvx synix show final-report --raw # full JSON with metadata and hashes
+uvx synix show final-report --raw # full JSON with metadata and artifact IDs
 ```
 
 Validate and search:
@@ -77,7 +77,7 @@ Build output lives in `./build/` — JSON files per artifact, a `manifest.json` 
 
 ```bash
 ls build/layer2-cs_product_brief/
-sqlite3 build/search.db "SELECT artifact_id, layer_name FROM search_index LIMIT 5"
+sqlite3 build/search.db "SELECT label, layer_name FROM search_index LIMIT 5"
 ```
 
 ## Defining a Pipeline
@@ -206,8 +206,8 @@ Drop files into `source_dir` — the `parse` transform auto-detects format by fi
 | `uvx synix build` | Run the pipeline. Only rebuilds what changed. |
 | `uvx synix plan` | Dry-run — show what would build without running transforms. |
 | `uvx synix plan --explain-cache` | Plan with inline cache decision reasons per artifact. |
-| `uvx synix list [layer]` | List all artifacts with short content hashes, optionally filtered by layer. |
-| `uvx synix show <id>` | Display an artifact's content. Resolves by ID or hash prefix. `--raw` for JSON. |
+| `uvx synix list [layer]` | List all artifacts with short artifact IDs, optionally filtered by layer. |
+| `uvx synix show <id>` | Display an artifact's content. Resolves by label or artifact ID prefix. `--raw` for JSON. |
 | `uvx synix search <query>` | Full-text search across indexed layers. `--mode hybrid` for semantic. |
 | `uvx synix validate` | Run declared validators against build artifacts. |
 | `uvx synix fix` | LLM-assisted repair of validation violations. |
@@ -229,7 +229,7 @@ Commands that take a pipeline path (`build`, `plan`, `validate`, `fix`, `clean`)
 
 **Full provenance** — Every artifact chains back to the source conversations that produced it, through every transform in between.
 
-**Git-like artifact resolution** — `uvx synix show` resolves artifacts by unique prefix of artifact ID or content hash, just like `git show` resolves commits.
+**Git-like artifact resolution** — `uvx synix show` resolves artifacts by unique prefix of label or artifact ID, just like `git show` resolves commits.
 
 **Validation and repair** — Detect semantic contradictions and PII leaks across artifacts, then fix them with LLM-assisted rewrites.
 
@@ -255,7 +255,7 @@ These are the highest-priority open issues. See the [issue tracker](https://gith
 |-------|----------|-------------|
 | [#53](https://github.com/marklubin/synix/issues/53) | P0 | **Parser metadata passthrough** — YAML frontmatter fields in source files are not propagated to artifact metadata. Custom fields like `author` or `date` are silently dropped. |
 | [#52](https://github.com/marklubin/synix/issues/52) | P0 | **Validate/verify and trace artifacts** — Trace artifacts from provenance tracking can trigger false positives in validators that expect only content artifacts. |
-| [#57](https://github.com/marklubin/synix/issues/57) | P1 | **Rich search output** — Search results show artifact IDs but not inline content snippets or provenance context. Requires multiple commands to get the full picture. |
+| [#57](https://github.com/marklubin/synix/issues/57) | P1 | **Rich search output** — Search results show artifact labels but not inline content snippets or provenance context. Requires multiple commands to get the full picture. |
 | [#56](https://github.com/marklubin/synix/issues/56) | P1 | **Provenance summarization** — Lineage output is raw dependency chains. No summarized view or filtering for large graphs. |
 | [#55](https://github.com/marklubin/synix/issues/55) | P1 | **Pipeline-relative imports** — Custom transforms using relative imports fail when the pipeline file is outside the project root. |
 | [#54](https://github.com/marklubin/synix/issues/54) | P1 | **Non-interactive automation mode** — No `--quiet` / `--json` output mode for CI or scripted usage. Rich formatting assumes a TTY. |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -380,7 +380,7 @@ Combine records from multiple sources with deduplication. Merge sits at the top 
 ```python
 pipeline.merge("unified",
     from_=["chatgpt", "claude"],
-    dedupe="content_hash",      # default: exact content match
+    dedupe="artifact_id",       # default: exact content match
     # dedupe="metadata_match",  # match on specific fields
     # dedupe="fuzzy",           # similarity threshold (future)
     conflict="prefer_latest"    # or: prefer_first, keep_all
@@ -388,7 +388,7 @@ pipeline.merge("unified",
 ```
 
 Dedup options:
-- `content_hash` — SHA-256 of content. Exact duplicates only. Fast and safe.
+- `artifact_id` — SHA-256 of content. Exact duplicates only. Fast and safe.
 - `metadata_match` — Match on specified fields (e.g., `conversation_id`). For when same conversation appears in multiple exports with different formatting.
 - `fuzzy` (future) — Semantic similarity above threshold. Dangerous — requires careful tuning.
 

--- a/docs/build-phases.md
+++ b/docs/build-phases.md
@@ -7,13 +7,13 @@
 - Directory structure, empty __init__.py files, pytest structure
 
 **1b. Artifact store** (`artifacts/store.py`)
-- `save_artifact(artifact)` / `load_artifact(artifact_id)` / `list_artifacts(layer)` / `get_content_hash(artifact_id)`
+- `save_artifact(artifact)` / `load_artifact(label)` / `list_artifacts(layer)` / `get_artifact_id(label)`
 - Manifest management (manifest.json)
 - Tests: save/load roundtrip, list by layer, hash checking
 
 **1c. Provenance** (`artifacts/provenance.py`)
-- `record(artifact_id, parent_ids, prompt_id, model_config)`
-- `get_parents(artifact_id)` / `get_chain(artifact_id)` — recursive walk to roots
+- `record(label, parent_ids, prompt_id, model_config)`
+- `get_parents(label)` / `get_chain(label)` — recursive walk to roots
 - Backed by provenance.json
 - Tests: record and retrieve, chain walking
 

--- a/docs/cache-semantics.md
+++ b/docs/cache-semantics.md
@@ -6,7 +6,7 @@ Synix uses a fingerprint-based caching system to determine when artifacts need r
 
 | Change | Triggers Rebuild? | Fingerprint Component | Notes |
 |--------|-------------------|-----------------------|-------|
-| Source file content | Yes | `inputs` | Upstream content_hash changes |
+| Source file content | Yes | `inputs` | Upstream artifact_id changes |
 | Prompt template file | Yes | `prompt` | Part of transform fingerprint |
 | LLM config (model, temp) | Yes | `model` | Part of transform fingerprint |
 | Transform config (topics, budget) | Yes | `config` | Part of transform fingerprint |
@@ -38,8 +38,8 @@ A fingerprint has three parts:
 | Scheme | Entity | Components |
 |--------|--------|------------|
 | `synix:transform:v1` | Transform identity | `source`, `prompt`, `config`, `model` |
-| `synix:build:v1` | Per-artifact build context | `transform` (digest), `inputs` (sorted input hashes) |
-| `synix:projection:v1` | Projection identity | `sources` (artifact hashes), `config` |
+| `synix:build:v1` | Per-artifact build context | `transform` (digest), `inputs` (sorted input IDs) |
+| `synix:projection:v1` | Projection identity | `sources` (artifact IDs), `config` |
 
 ### Scheme Versioning
 

--- a/docs/cli-ux.md
+++ b/docs/cli-ux.md
@@ -22,7 +22,7 @@ Every CLI command must show live interactive progress. The user must never stare
 ## Per-Command UX
 
 - **`synix run`**: Rich progress bars per layer. Show: layer name, artifact count, built/cached/skipped. Final summary table with timing.
-- **`synix search`**: Results as Rich panels — layer label colored by level, content snippet, artifact ID. Provenance chain as indented tree below each result.
+- **`synix search`**: Results as Rich panels — layer label colored by level, content snippet, artifact label. Provenance chain as indented tree below each result.
 - **`synix lineage`**: Rich Tree widget — full dependency graph from artifact to raw transcript.
 - **`synix status`**: Rich table — layer name, artifact count, last build time, cache hit ratio.
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -50,9 +50,9 @@ def tmp_build_dir(tmp_path):
 def sample_artifacts():
     """Pre-built artifacts for testing downstream modules."""
     return [
-        Artifact(artifact_id="t-001", artifact_type="transcript", content="...", ...),
-        Artifact(artifact_id="t-002", artifact_type="transcript", content="...", ...),
-        Artifact(artifact_id="ep-001", artifact_type="episode", content="...", ...),
+        Artifact(label="t-001", artifact_type="transcript", content="...", ...),
+        Artifact(label="t-002", artifact_type="transcript", content="...", ...),
+        Artifact(label="ep-001", artifact_type="episode", content="...", ...),
     ]
 
 @pytest.fixture
@@ -81,7 +81,7 @@ def sample_pipeline(tmp_build_dir):
 - `test_save_and_load_roundtrip` — save artifact, load by ID, content matches
 - `test_load_nonexistent_returns_none`
 - `test_list_by_layer` — save 5 artifacts across 3 layers, list each correctly
-- `test_content_hash_computed` — hash is SHA256 of content
+- `test_artifact_id_computed` — artifact_id is SHA256 of content
 - `test_manifest_persistence` — save artifacts, reload store, manifest intact
 - `test_overwrite_artifact` — save same ID twice, latest wins
 

--- a/llms.txt
+++ b/llms.txt
@@ -35,16 +35,18 @@ uvx synix validate
 
 ## CLI commands
 
-- `uvx synix init <name>` — scaffold new project with sources, pipeline, and README
-- `uvx synix build [pipeline.py]` — run pipeline, only rebuild what changed
-- `uvx synix plan [pipeline.py]` — dry-run showing what would build, cost estimates
-- `uvx synix search <query>` — full-text search with provenance chains
-- `uvx synix validate [pipeline.py]` — run declared validators against artifacts
-- `uvx synix list [layer]` — show all artifacts, optionally filtered by layer
-- `uvx synix show <id>` — display artifact content (`--raw` for JSON)
-- `uvx synix lineage <id>` — show full provenance chain for artifact
-- `uvx synix verify [pipeline.py]` — check build integrity (hashes, provenance)
-- `uvx synix clean [pipeline.py]` — delete build directory
+```bash
+uvx synix init <name>           # Scaffold new project
+uvx synix build                 # Run pipeline, only rebuild what changed
+uvx synix plan                  # Dry-run showing what would build
+uvx synix plan --explain-cache  # Plan with inline cache decision reasons
+uvx synix search "query"        # Full-text search with provenance
+uvx synix show <id-or-prefix>   # Display artifact (resolves by label or artifact ID prefix)
+uvx synix validate              # Run declared validators
+uvx synix list [layer]          # Browse artifacts with short artifact IDs
+uvx synix lineage <id>          # Show provenance tree
+uvx synix clean                 # Delete build directory
+```
 
 ## Architecture overview
 
@@ -103,6 +105,16 @@ pipeline.add_projection(Projection(
     sources=[{"layer": "episodes"}, {"layer": "monthly"}, {"layer": "core"}]
 ))
 ```
+
+## Known limitations
+
+- **Removed source files leave orphans** — deleting a source file does not remove downstream artifacts. Run `clean` and rebuild.
+- **YAML frontmatter fields dropped** — parser does not pass through custom frontmatter metadata to artifacts (#53).
+- **Trace artifacts affect validators** — provenance trace artifacts can trigger false positives in content validators (#52).
+- **No CI/automation output mode** — Rich formatting assumes a TTY; no `--quiet` or `--json` flag for scripted usage (#54).
+- **Relative imports in custom transforms** — fail when pipeline file is outside project root (#55).
+- **Search shows labels only** — no inline content snippets or provenance in search results (#57).
+- **Embedding failures are silent** — search indexing falls back to keyword-only without warning (#33).
 
 ## Important constraints
 

--- a/src/synix/__init__.py
+++ b/src/synix/__init__.py
@@ -3,7 +3,7 @@
 Re-export core models for backward compatibility.
 """
 
-__version__ = "0.9.5"
+__version__ = "0.10.0"
 
 from synix.core.models import (  # noqa: F401
     Artifact,

--- a/src/synix/adapters/chatgpt.py
+++ b/src/synix/adapters/chatgpt.py
@@ -85,7 +85,7 @@ def parse_chatgpt(filepath: str | Path) -> list[Artifact]:
 
         artifacts.append(
             Artifact(
-                artifact_id=f"t-chatgpt-{conv_id}",
+                label=f"t-chatgpt-{conv_id}",
                 artifact_type="transcript",
                 content=content,
                 metadata=metadata,

--- a/src/synix/adapters/claude.py
+++ b/src/synix/adapters/claude.py
@@ -89,7 +89,7 @@ def parse_claude(filepath: str | Path) -> list[Artifact]:
 
         artifacts.append(
             Artifact(
-                artifact_id=f"t-claude-{uuid}",
+                label=f"t-claude-{uuid}",
                 artifact_type="transcript",
                 content=content,
                 metadata={

--- a/src/synix/adapters/text.py
+++ b/src/synix/adapters/text.py
@@ -69,9 +69,9 @@ def parse_text(filepath: str | Path) -> list[Artifact]:
     # Count messages if conversation format
     message_count = len(_TURN_RE.findall(body)) if has_turns else 0
 
-    # Sanitize filename stem for artifact ID
+    # Sanitize filename stem for label
     safe_stem = _sanitize_id(filepath.stem)
-    artifact_id = f"t-text-{safe_stem}"
+    label = f"t-text-{safe_stem}"
 
     metadata: dict = {
         "source": "text",
@@ -87,7 +87,7 @@ def parse_text(filepath: str | Path) -> list[Artifact]:
 
     return [
         Artifact(
-            artifact_id=artifact_id,
+            label=label,
             artifact_type="transcript",
             content=content,
             metadata=metadata,

--- a/src/synix/build/artifacts.py
+++ b/src/synix/build/artifacts.py
@@ -30,21 +30,21 @@ class ArtifactStore:
 
     def save_artifact(self, artifact: Artifact, layer_name: str, layer_level: int) -> None:
         """Save an artifact to the build directory."""
-        # Ensure content hash is computed
-        if not artifact.content_hash and artifact.content:
-            artifact.content_hash = f"sha256:{hashlib.sha256(artifact.content.encode()).hexdigest()}"
+        # Ensure artifact ID (content hash) is computed
+        if not artifact.artifact_id and artifact.content:
+            artifact.artifact_id = f"sha256:{hashlib.sha256(artifact.content.encode()).hexdigest()}"
 
         # Create layer directory
         layer_dir = self.build_dir / f"layer{layer_level}-{layer_name}"
         layer_dir.mkdir(parents=True, exist_ok=True)
 
         # Serialize artifact to JSON
-        artifact_path = layer_dir / f"{artifact.artifact_id}.json"
+        artifact_path = layer_dir / f"{artifact.label}.json"
         artifact_data = {
-            "artifact_id": artifact.artifact_id,
+            "label": artifact.label,
             "artifact_type": artifact.artifact_type,
-            "content_hash": artifact.content_hash,
-            "input_hashes": artifact.input_hashes,
+            "artifact_id": artifact.artifact_id,
+            "input_ids": artifact.input_ids,
             "prompt_id": artifact.prompt_id,
             "model_config": artifact.model_config,
             "created_at": artifact.created_at.isoformat(),
@@ -53,19 +53,19 @@ class ArtifactStore:
         }
         atomic_write(artifact_path, json.dumps(artifact_data, indent=2))
 
-        # Update manifest
-        rel_path = f"layer{layer_level}-{layer_name}/{artifact.artifact_id}.json"
-        self._manifest[artifact.artifact_id] = {
+        # Update manifest (keyed by label)
+        rel_path = f"layer{layer_level}-{layer_name}/{artifact.label}.json"
+        self._manifest[artifact.label] = {
             "path": rel_path,
-            "content_hash": artifact.content_hash,
+            "artifact_id": artifact.artifact_id,
             "layer": layer_name,
             "level": layer_level,
         }
         self._save_manifest()
 
-    def load_artifact(self, artifact_id: str) -> Artifact | None:
-        """Load an artifact by ID. Returns None if not found."""
-        entry = self._manifest.get(artifact_id)
+    def load_artifact(self, label: str) -> Artifact | None:
+        """Load an artifact by label. Returns None if not found."""
+        entry = self._manifest.get(label)
         if entry is None:
             return None
 
@@ -75,10 +75,10 @@ class ArtifactStore:
 
         data = json.loads(artifact_path.read_text())
         return Artifact(
-            artifact_id=data["artifact_id"],
+            label=data["label"],
             artifact_type=data["artifact_type"],
-            content_hash=data["content_hash"],
-            input_hashes=data.get("input_hashes", []),
+            artifact_id=data["artifact_id"],
+            input_ids=data.get("input_ids", []),
             prompt_id=data.get("prompt_id"),
             model_config=data.get("model_config"),
             created_at=datetime.fromisoformat(data["created_at"]),
@@ -89,54 +89,54 @@ class ArtifactStore:
     def list_artifacts(self, layer: str) -> list[Artifact]:
         """Return all artifacts for a given layer name."""
         artifacts = []
-        for artifact_id, entry in self._manifest.items():
+        for label, entry in self._manifest.items():
             if entry["layer"] == layer:
-                artifact = self.load_artifact(artifact_id)
+                artifact = self.load_artifact(label)
                 if artifact is not None:
                     artifacts.append(artifact)
         return artifacts
 
-    def get_content_hash(self, artifact_id: str) -> str | None:
-        """Quick hash lookup from manifest without loading full artifact."""
-        entry = self._manifest.get(artifact_id)
+    def get_artifact_id(self, label: str) -> str | None:
+        """Quick artifact ID (hash) lookup from manifest without loading full artifact."""
+        entry = self._manifest.get(label)
         if entry is None:
             return None
-        return entry["content_hash"]
+        return entry["artifact_id"]
 
     def resolve_prefix(self, prefix: str) -> str | None:
-        """Resolve a prefix to a full artifact_id (git-like semantics).
+        """Resolve a prefix to a full label (git-like semantics).
 
-        Matches against artifact IDs first, then content hashes.
-        Returns the full artifact_id on unique match, None if no match.
+        Matches against labels first, then artifact IDs (hashes).
+        Returns the full label on unique match, None if no match.
         Raises ValueError on ambiguous match (multiple candidates).
         """
         # Strip sha256: prefix if user pasted a full hash
         hash_prefix = prefix.removeprefix("sha256:")
 
-        # 1. Exact match on artifact_id
+        # 1. Exact match on label
         if prefix in self._manifest:
             return prefix
 
-        # 2. Prefix match on artifact_id
-        id_matches = [aid for aid in self._manifest if aid.startswith(prefix)]
-        if len(id_matches) == 1:
-            return id_matches[0]
-        if len(id_matches) > 1:
-            ids = ", ".join(sorted(id_matches)[:5])
-            msg = f"ambiguous prefix '{prefix}' matches {len(id_matches)} artifact IDs: {ids}"
+        # 2. Prefix match on label
+        label_matches = [lbl for lbl in self._manifest if lbl.startswith(prefix)]
+        if len(label_matches) == 1:
+            return label_matches[0]
+        if len(label_matches) > 1:
+            labels = ", ".join(sorted(label_matches)[:5])
+            msg = f"ambiguous prefix '{prefix}' matches {len(label_matches)} labels: {labels}"
             raise ValueError(msg)
 
-        # 3. Prefix match on content_hash (with or without sha256: prefix)
+        # 3. Prefix match on artifact ID (hash) (with or without sha256: prefix)
         hash_matches = [
-            aid
-            for aid, entry in self._manifest.items()
-            if entry["content_hash"].removeprefix("sha256:").startswith(hash_prefix)
+            lbl
+            for lbl, entry in self._manifest.items()
+            if entry["artifact_id"].removeprefix("sha256:").startswith(hash_prefix)
         ]
         if len(hash_matches) == 1:
             return hash_matches[0]
         if len(hash_matches) > 1:
-            ids = ", ".join(sorted(hash_matches)[:5])
-            msg = f"ambiguous hash prefix '{prefix}' matches {len(hash_matches)} artifacts: {ids}"
+            labels = ", ".join(sorted(hash_matches)[:5])
+            msg = f"ambiguous hash prefix '{prefix}' matches {len(hash_matches)} artifacts: {labels}"
             raise ValueError(msg)
 
         return None

--- a/src/synix/build/dag.py
+++ b/src/synix/build/dag.py
@@ -45,8 +45,8 @@ def resolve_build_order(pipeline: Pipeline) -> list[Layer]:
 
 
 def needs_rebuild(
-    artifact_id: str,
-    current_input_hashes: list[str],
+    label: str,
+    current_input_ids: list[str],
     store,
     current_build_fingerprint: Fingerprint | None = None,
 ) -> tuple[bool, list[str]]:
@@ -56,9 +56,9 @@ def needs_rebuild(
     strings explaining why a rebuild is needed.
 
     Uses build fingerprint comparison: the fingerprint encodes transform identity
-    (source code, prompt, model, config) plus input hashes into a single digest.
+    (source code, prompt, model, config) plus input IDs into a single digest.
     """
-    existing = store.load_artifact(artifact_id)
+    existing = store.load_artifact(label)
     if existing is None:
         return (True, ["new artifact"])
 
@@ -75,7 +75,7 @@ def needs_rebuild(
         reasons = current_build_fingerprint.explain_diff(stored_fp)
         return (True, reasons)
 
-    # No fingerprint provided — can only check input hashes
-    if sorted(existing.input_hashes) != sorted(current_input_hashes):
+    # No fingerprint provided — can only check input IDs
+    if sorted(existing.input_ids) != sorted(current_input_ids):
         return (True, ["inputs changed"])
     return (False, [])

--- a/src/synix/build/diff.py
+++ b/src/synix/build/diff.py
@@ -15,7 +15,7 @@ from synix.core.models import Artifact
 class ArtifactDiff:
     """Diff result for a single artifact."""
 
-    artifact_id: str
+    label: str
     has_changes: bool
     content_diff: str  # unified diff of content
     metadata_diff: dict  # changed metadata keys
@@ -47,8 +47,8 @@ def diff_artifact(old: Artifact, new: Artifact) -> ArtifactDiff:
         difflib.unified_diff(
             old_lines,
             new_lines,
-            fromfile=f"a/{old.artifact_id}",
-            tofile=f"b/{new.artifact_id}",
+            fromfile=f"a/{old.label}",
+            tofile=f"b/{new.label}",
             lineterm="",
         )
     )
@@ -63,16 +63,16 @@ def diff_artifact(old: Artifact, new: Artifact) -> ArtifactDiff:
             metadata_diff[key] = {"old": old_val, "new": new_val}
 
     has_changes = bool(
-        content_diff or metadata_diff or old.content_hash != new.content_hash or old.prompt_id != new.prompt_id
+        content_diff or metadata_diff or old.artifact_id != new.artifact_id or old.prompt_id != new.prompt_id
     )
 
     return ArtifactDiff(
-        artifact_id=old.artifact_id,
+        label=old.label,
         has_changes=has_changes,
         content_diff=content_diff,
         metadata_diff=metadata_diff,
-        old_hash=old.content_hash,
-        new_hash=new.content_hash,
+        old_hash=old.artifact_id,
+        new_hash=new.artifact_id,
         old_prompt_id=old.prompt_id,
         new_prompt_id=new.prompt_id,
     )
@@ -107,8 +107,8 @@ def diff_builds(old_build_dir: str | Path, new_build_dir: str | Path, layer: str
     return result
 
 
-def diff_artifact_by_id(
-    build_dir: str | Path, artifact_id: str, previous_build_dir: str | Path | None = None
+def diff_artifact_by_label(
+    build_dir: str | Path, label: str, previous_build_dir: str | Path | None = None
 ) -> ArtifactDiff | None:
     """Diff a specific artifact against its previous version.
 
@@ -116,19 +116,19 @@ def diff_artifact_by_id(
     Otherwise, checks for version history in the same build directory.
     """
     store = ArtifactStore(build_dir)
-    new_art = store.load_artifact(artifact_id)
+    new_art = store.load_artifact(label)
     if new_art is None:
         return None
 
     if previous_build_dir:
         old_store = ArtifactStore(previous_build_dir)
-        old_art = old_store.load_artifact(artifact_id)
+        old_art = old_store.load_artifact(label)
         if old_art is None:
             return None
         return diff_artifact(old_art, new_art)
 
     # No previous build dir — check for version history
-    versions_dir = Path(build_dir) / "versions" / artifact_id
+    versions_dir = Path(build_dir) / "versions" / label
     if not versions_dir.exists():
         return None
 
@@ -142,10 +142,10 @@ def diff_artifact_by_id(
     from datetime import datetime
 
     old_art = Artifact(
-        artifact_id=data["artifact_id"],
+        label=data["label"],
         artifact_type=data["artifact_type"],
-        content_hash=data["content_hash"],
-        input_hashes=data.get("input_hashes", []),
+        artifact_id=data["artifact_id"],
+        input_ids=data.get("input_ids", []),
         prompt_id=data.get("prompt_id"),
         model_config=data.get("model_config"),
         created_at=datetime.fromisoformat(data["created_at"]),

--- a/src/synix/build/fingerprint.py
+++ b/src/synix/build/fingerprint.py
@@ -93,12 +93,12 @@ def fingerprint_value(obj) -> str:
 
 def compute_build_fingerprint(
     transform_fingerprint: Fingerprint,
-    input_hashes: list[str],
+    input_ids: list[str],
 ) -> Fingerprint:
-    """Combine transform identity with input hashes into a build fingerprint."""
+    """Combine transform identity with input IDs into a build fingerprint."""
     components = {
         "transform": transform_fingerprint.digest,
-        "inputs": fingerprint_value(input_hashes),
+        "inputs": fingerprint_value(input_ids),
     }
     return Fingerprint(
         scheme="synix:build:v1",

--- a/src/synix/build/provenance.py
+++ b/src/synix/build/provenance.py
@@ -29,58 +29,58 @@ class ProvenanceTracker:
 
     def record(
         self,
-        artifact_id: str,
-        parent_ids: list[str],
+        label: str,
+        parent_labels: list[str],
         prompt_id: str | None = None,
         model_config: dict | None = None,
     ) -> None:
         """Record provenance for an artifact."""
-        self._records[artifact_id] = {
-            "artifact_id": artifact_id,
-            "parent_artifact_ids": parent_ids,
+        self._records[label] = {
+            "label": label,
+            "parent_labels": parent_labels,
             "prompt_id": prompt_id,
             "model_config": model_config,
             "created_at": datetime.now().isoformat(),
         }
         self._save()
 
-    def get_parents(self, artifact_id: str) -> list[str]:
-        """Return parent artifact IDs for this artifact."""
-        rec = self._records.get(artifact_id)
+    def get_parents(self, label: str) -> list[str]:
+        """Return parent labels for this artifact."""
+        rec = self._records.get(label)
         if rec is None:
             return []
-        return rec["parent_artifact_ids"]
+        return rec["parent_labels"]
 
-    def get_record(self, artifact_id: str) -> ProvenanceRecord | None:
+    def get_record(self, label: str) -> ProvenanceRecord | None:
         """Return the ProvenanceRecord for an artifact, or None."""
-        rec = self._records.get(artifact_id)
+        rec = self._records.get(label)
         if rec is None:
             return None
         return ProvenanceRecord(
-            artifact_id=rec["artifact_id"],
-            parent_artifact_ids=rec["parent_artifact_ids"],
+            label=rec["label"],
+            parent_labels=rec["parent_labels"],
             prompt_id=rec.get("prompt_id"),
             model_config=rec.get("model_config"),
             created_at=datetime.fromisoformat(rec["created_at"]),
         )
 
-    def get_chain(self, artifact_id: str) -> list[ProvenanceRecord]:
+    def get_chain(self, label: str) -> list[ProvenanceRecord]:
         """Recursive walk to roots — return full provenance chain (BFS)."""
         chain: list[ProvenanceRecord] = []
         visited: set[str] = set()
-        queue: list[str] = [artifact_id]
+        queue: list[str] = [label]
 
         while queue:
-            current_id = queue.pop(0)
-            if current_id in visited:
+            current_label = queue.pop(0)
+            if current_label in visited:
                 continue
-            visited.add(current_id)
+            visited.add(current_label)
 
-            record = self.get_record(current_id)
+            record = self.get_record(current_label)
             if record is not None:
                 chain.append(record)
-                for parent_id in record.parent_artifact_ids:
-                    if parent_id not in visited:
-                        queue.append(parent_id)
+                for parent_label in record.parent_labels:
+                    if parent_label not in visited:
+                        queue.append(parent_label)
 
         return chain

--- a/src/synix/build/verify.py
+++ b/src/synix/build/verify.py
@@ -161,7 +161,7 @@ def _check_manifest_valid(build_path: Path) -> VerifyCheck:
         if not isinstance(entry, dict):
             issues.append(f"{aid}: entry is not a dict")
             continue
-        for key in ("path", "content_hash", "layer", "level"):
+        for key in ("path", "artifact_id", "layer", "level"):
             if key not in entry:
                 issues.append(f"{aid}: missing key '{key}'")
 
@@ -325,8 +325,8 @@ def _check_content_hashes(build_path: Path) -> VerifyCheck:
         if artifact is None:
             continue
         expected_hash = f"sha256:{hashlib.sha256(artifact.content.encode()).hexdigest()}"
-        if artifact.content_hash != expected_hash:
-            mismatches.append(f"{aid}: stored={artifact.content_hash[:20]}... computed={expected_hash[:20]}...")
+        if artifact.artifact_id != expected_hash:
+            mismatches.append(f"{aid}: stored={artifact.artifact_id[:20]}... computed={expected_hash[:20]}...")
 
     if mismatches:
         return VerifyCheck(
@@ -441,7 +441,7 @@ def _check_merge_integrity(build_path: Path) -> VerifyCheck:
 
         # Also walk provenance to find customer_ids from source artifacts
         if merge_id in provenance:
-            parent_ids = provenance[merge_id].get("parent_artifact_ids", [])
+            parent_ids = provenance[merge_id].get("parent_labels", [])
             for parent_id in parent_ids:
                 parent = store.load_artifact(parent_id)
                 if parent and parent.metadata.get("customer_id"):

--- a/src/synix/cli/artifact_commands.py
+++ b/src/synix/cli/artifact_commands.py
@@ -38,11 +38,11 @@ def list_artifacts(layer: str | None, build_dir: str):
 
     # Group by layer, sorted by level
     by_layer: dict[str, list[tuple[str, dict]]] = {}
-    for artifact_id, info in manifest.items():
+    for art_label, info in manifest.items():
         layer_name = info.get("layer", "unknown")
         if layer and layer_name != layer:
             continue
-        by_layer.setdefault(layer_name, []).append((artifact_id, info))
+        by_layer.setdefault(layer_name, []).append((art_label, info))
 
     if not by_layer:
         if layer:
@@ -66,21 +66,21 @@ def list_artifacts(layer: str | None, build_dir: str):
             box=box.ROUNDED,
             show_header=True,
         )
-        table.add_column("Artifact ID", style="bold", no_wrap=True)
-        table.add_column("Hash", style="dim", no_wrap=True)
+        table.add_column("Label", style="bold", no_wrap=True)
+        table.add_column("Artifact ID", style="dim", no_wrap=True)
         table.add_column("Date", no_wrap=True)
         table.add_column("Title / Summary", max_width=60)
 
         # Load each artifact to get metadata for display
-        for artifact_id, _info in sorted(entries, key=lambda x: x[0]):
-            artifact = store.load_artifact(artifact_id)
+        for art_label, _info in sorted(entries, key=lambda x: x[0]):
+            artifact = store.load_artifact(art_label)
             if artifact is None:
-                table.add_row(artifact_id, "-", "-", "[dim]<missing>[/dim]")
+                table.add_row(art_label, "-", "-", "[dim]<missing>[/dim]")
                 continue
 
-            # Short hash (7 chars like git)
-            raw_hash = (artifact.content_hash or "").removeprefix("sha256:")
-            short_hash = raw_hash[:7] if raw_hash else "-"
+            # Short artifact ID (7 chars like git)
+            raw_id = (artifact.artifact_id or "").removeprefix("sha256:")
+            short_id = raw_id[:7] if raw_id else "-"
 
             # Extract date and title from metadata
             date = artifact.metadata.get("date", "")
@@ -96,7 +96,7 @@ def list_artifacts(layer: str | None, build_dir: str):
                 if len(title) > 60:
                     title = title[:57] + "..."
 
-            table.add_row(artifact_id, short_hash, str(date), title)
+            table.add_row(art_label, short_id, str(date), title)
 
         console.print(table)
         console.print()
@@ -141,10 +141,10 @@ def show_artifact(artifact_id: str, build_dir: str, raw: bool):
     if raw:
         # Show full JSON representation
         data = {
-            "artifact_id": artifact.artifact_id,
+            "label": artifact.label,
             "artifact_type": artifact.artifact_type,
-            "content_hash": artifact.content_hash,
-            "input_hashes": artifact.input_hashes,
+            "artifact_id": artifact.artifact_id,
+            "input_ids": artifact.input_ids,
             "prompt_id": artifact.prompt_id,
             "model_config": artifact.model_config,
             "created_at": artifact.created_at.isoformat(),

--- a/src/synix/cli/build_commands.py
+++ b/src/synix/cli/build_commands.py
@@ -228,13 +228,13 @@ def _display_validation_results(validation):
         console.print(f"\n[bold]{name}[/bold] violations:")
         for v in viol_list:
             severity_style = "red" if v.severity == "error" else "yellow"
-            console.print(f"  [{severity_style}]{v.artifact_id}[/{severity_style}]: {v.message}")
+            console.print(f"  [{severity_style}]{v.label}[/{severity_style}]: {v.message}")
 
             if v.provenance_trace:
                 console.print("    [dim]Provenance:[/dim]")
                 for step in v.provenance_trace:
                     val_str = f"  {v.field}: {step.field_value}" if step.field_value else ""
-                    console.print(f"      {step.artifact_id} [dim]({step.layer})[/dim]{val_str}")
+                    console.print(f"      {step.label} [dim]({step.layer})[/dim]{val_str}")
 
 
 # Hidden alias for backward compatibility
@@ -616,7 +616,7 @@ def _save_plan_artifact(build_plan, pipeline):
 
     content = build_plan.to_json()
     artifact = Artifact(
-        artifact_id="build-plan",
+        label="build-plan",
         artifact_type="build_plan",
         content=content,
         metadata={

--- a/src/synix/cli/search_commands.py
+++ b/src/synix/cli/search_commands.py
@@ -123,7 +123,7 @@ def search(
         store = ArtifactStore(build_dir)
         filtered = []
         for result in results:
-            artifact = store.load_artifact(result.artifact_id)
+            artifact = store.load_artifact(result.label)
             if artifact is not None:
                 if artifact.metadata.get("customer_id") == customer:
                     filtered.append(result)
@@ -170,7 +170,7 @@ def search(
         score_display = "".join(score_parts)
 
         footer = Text.from_markup(
-            f"[dim]Artifact:[/dim] {result.artifact_id}  "
+            f"[dim]Label:[/dim] {result.label}  "
             f"[dim]Score:[/dim] {score_display}  [dim]Mode:[/dim] {search_mode_label}"
         )
 
@@ -195,16 +195,16 @@ def search(
                 visited.add(aid)
                 rec = provenance.get_record(aid)
                 if rec:
-                    for parent_id in sorted(rec.parent_artifact_ids):
-                        label = f"[dim]{parent_id}[/dim]"
-                        child = node.add(label)
-                        _build_trace_tree(child, parent_id, visited)
+                    for parent_label in sorted(rec.parent_labels):
+                        tree_label = f"[dim]{parent_label}[/dim]"
+                        child = node.add(tree_label)
+                        _build_trace_tree(child, parent_label, visited)
 
-            _build_trace_tree(prov_tree, result.artifact_id)
+            _build_trace_tree(prov_tree, result.label)
             console.print(prov_tree)
         elif not trace and result.provenance_chain:
             # Legacy behavior: show simple provenance tree without --trace
-            tree = Tree(f"[dim]{result.artifact_id}[/dim]")
+            tree = Tree(f"[dim]{result.label}[/dim]")
 
             def _add_parents(node, aid, visited=None):
                 if visited is None:
@@ -214,11 +214,11 @@ def search(
                 visited.add(aid)
                 rec = provenance.get_record(aid)
                 if rec:
-                    for parent_id in sorted(rec.parent_artifact_ids):
-                        child = node.add(f"[dim]{parent_id}[/dim]")
-                        _add_parents(child, parent_id, visited)
+                    for parent_label in sorted(rec.parent_labels):
+                        child = node.add(f"[dim]{parent_label}[/dim]")
+                        _add_parents(child, parent_label, visited)
 
-            _add_parents(tree, result.artifact_id)
+            _add_parents(tree, result.label)
             console.print(tree)
 
         console.print()

--- a/src/synix/cli/validate_commands.py
+++ b/src/synix/cli/validate_commands.py
@@ -87,7 +87,7 @@ def _run_validators_with_progress(pipeline, store, provenance, output_json: bool
         # Auto-resolve provenance for violations without traces
         for v in violations:
             if not v.provenance_trace:
-                v.provenance_trace = ctx.trace_field_origin(v.artifact_id, v.field)
+                v.provenance_trace = ctx.trace_field_origin(v.label, v.field)
 
         result.violations.extend(violations)
         result.validators_run.append(decl.name)
@@ -215,10 +215,10 @@ def _run_validate_mode(pipeline, build_path: Path, output_json: bool):
             provenance_tree = Tree("[dim]Provenance[/dim]")
             parent = provenance_tree
             for step in v.provenance_trace:
-                label = f"[bold]{step.artifact_id}[/bold] [dim]({step.layer})[/dim]"
+                step_display = f"[bold]{step.label}[/bold] [dim]({step.layer})[/dim]"
                 if step.field_value:
-                    label += f"  {v.field}: {step.field_value}"
-                parent = parent.add(label)
+                    step_display += f"  {v.field}: {step.field_value}"
+                parent = parent.add(step_display)
             panel_content = Group(body, "", provenance_tree)
         else:
             panel_content = body
@@ -230,7 +230,7 @@ def _run_validate_mode(pipeline, build_path: Path, output_json: bool):
                 title=(
                     f"[red bold]ERROR[/red bold]"
                     f" [dim]|[/dim] [red]{type_label}[/red]"
-                    f" [dim]|[/dim] [red]{v.artifact_id}[/red]"
+                    f" [dim]|[/dim] [red]{v.label}[/red]"
                 ),
                 border_style="red",
                 padding=(0, 1),
@@ -243,7 +243,7 @@ def _run_validate_mode(pipeline, build_path: Path, output_json: bool):
         console.print("[yellow bold]Warnings[/yellow bold]")
         for v in warnings:
             type_label = v.violation_type.replace("_", " ")
-            console.print(f"  [yellow]\u2022[/yellow] [dim]{type_label}[/dim]  {v.artifact_id}: {v.message}")
+            console.print(f"  [yellow]\u2022[/yellow] [dim]{type_label}[/dim]  {v.label}: {v.message}")
 
     error_count = sum(1 for v in result.violations if v.severity == "error")
     warn_count = sum(1 for v in result.violations if v.severity == "warning")

--- a/src/synix/cli/verify_commands.py
+++ b/src/synix/cli/verify_commands.py
@@ -41,9 +41,9 @@ def lineage(artifact_id: str, build_dir: str):
     tree = Tree(f"[bold]{artifact_id}[/bold]")
 
     def add_parents(node, aid):
-        record = next((r for r in chain if r.artifact_id == aid), None)
+        record = next((r for r in chain if r.label == aid), None)
         if record:
-            for parent_id in record.parent_artifact_ids:
+            for parent_id in record.parent_labels:
                 artifact = store.load_artifact(parent_id)
                 label = parent_id
                 if artifact:
@@ -235,13 +235,13 @@ def _display_domain_validations(validation):
         console.print(f"\n[bold]{name}[/bold] violations:")
         for v in viol_list:
             severity_style = "red" if v.severity == "error" else "yellow"
-            console.print(f"  [{severity_style}]{v.artifact_id}[/{severity_style}]: {v.message}")
+            console.print(f"  [{severity_style}]{v.label}[/{severity_style}]: {v.message}")
 
             if v.provenance_trace:
                 console.print("    [dim]Provenance:[/dim]")
                 for step in v.provenance_trace:
                     val_str = f"  {v.field}: {step.field_value}" if step.field_value else ""
-                    console.print(f"      {step.artifact_id} [dim]({step.layer})[/dim]{val_str}")
+                    console.print(f"      {step.label} [dim]({step.layer})[/dim]{val_str}")
 
 
 @click.command()
@@ -255,11 +255,11 @@ def diff(artifact_id: str | None, build_dir: str, old_build_dir: str | None, lay
     If ARTIFACT_ID is given, shows diff for that artifact.
     Otherwise, diffs all artifacts between two build directories.
     """
-    from synix.build.diff import diff_artifact_by_id, diff_builds
+    from synix.build.diff import diff_artifact_by_label, diff_builds
 
     if artifact_id:
         # Single artifact diff
-        result = diff_artifact_by_id(build_dir, artifact_id, previous_build_dir=old_build_dir)
+        result = diff_artifact_by_label(build_dir, artifact_id, previous_build_dir=old_build_dir)
         if result is None:
             console.print(f"[red]Cannot diff artifact:[/red] {artifact_id}")
             console.print("[dim]Either artifact not found or no previous version available.[/dim]")
@@ -313,7 +313,7 @@ def diff(artifact_id: str | None, build_dir: str, old_build_dir: str | None, lay
         if result.diffs:
             console.print(f"\n[yellow]~{len(result.diffs)} modified:[/yellow]")
             for d in result.diffs:
-                console.print(f"  [yellow]~ {d.artifact_id}[/yellow]")
+                console.print(f"  [yellow]~ {d.label}[/yellow]")
                 if d.content_diff:
                     lines = d.content_diff.count("\n")
                     console.print(f"    [dim]{lines} lines changed[/dim]")

--- a/src/synix/core/logging.py
+++ b/src/synix/core/logging.py
@@ -226,45 +226,45 @@ class SynixLogger:
 
     # -- Artifact events --
 
-    def artifact_built(self, layer_name: str, artifact_id: str) -> None:
+    def artifact_built(self, layer_name: str, label: str) -> None:
         """Log that an artifact was built (not cached)."""
         with self._lock:
             step = self.run_log.get_or_create_step(layer_name)
-            step.rebuilt_ids.append(artifact_id)
+            step.rebuilt_ids.append(label)
 
         self._write_event(
             {
                 "event": "artifact_built",
                 "layer": layer_name,
-                "artifact_id": artifact_id,
+                "label": label,
             }
         )
 
         self._console_print(
-            f"      [green]+[/green] {artifact_id}",
+            f"      [green]+[/green] {label}",
             Verbosity.VERBOSE,
         )
 
-    def artifact_cached(self, layer_name: str, artifact_id: str) -> None:
+    def artifact_cached(self, layer_name: str, label: str) -> None:
         """Log that an artifact was found in cache."""
         with self._lock:
             step = self.run_log.get_or_create_step(layer_name)
             step.cache_hits += 1
-            step.cached_ids.append(artifact_id)
+            step.cached_ids.append(label)
 
         self._write_event(
             {
                 "event": "artifact_cached",
                 "layer": layer_name,
-                "artifact_id": artifact_id,
+                "label": label,
             }
         )
 
         if self.progress:
-            self.progress.artifact_cached(artifact_id)
+            self.progress.artifact_cached(label)
 
         self._console_print(
-            f"      [cyan]=[/cyan] {artifact_id} (cached)",
+            f"      [cyan]=[/cyan] {label} (cached)",
             Verbosity.VERBOSE,
         )
 

--- a/src/synix/core/models.py
+++ b/src/synix/core/models.py
@@ -11,27 +11,27 @@ from datetime import datetime
 class Artifact:
     """Immutable, versioned build output."""
 
-    artifact_id: str
+    label: str
     artifact_type: str  # "transcript", "episode", "rollup", "core_memory", "search_index"
     content: str
-    content_hash: str = ""
-    input_hashes: list[str] = field(default_factory=list)
+    artifact_id: str = ""
+    input_ids: list[str] = field(default_factory=list)
     prompt_id: str | None = None
     model_config: dict | None = None
     created_at: datetime = field(default_factory=datetime.now)
     metadata: dict = field(default_factory=dict)
 
     def __post_init__(self):
-        if not self.content_hash and self.content:
-            self.content_hash = f"sha256:{hashlib.sha256(self.content.encode()).hexdigest()}"
+        if not self.artifact_id and self.content:
+            self.artifact_id = f"sha256:{hashlib.sha256(self.content.encode()).hexdigest()}"
 
 
 @dataclass
 class ProvenanceRecord:
     """Lineage record for an artifact."""
 
-    artifact_id: str
-    parent_artifact_ids: list[str] = field(default_factory=list)
+    label: str
+    parent_labels: list[str] = field(default_factory=list)
     prompt_id: str | None = None
     model_config: dict | None = None
     created_at: datetime = field(default_factory=datetime.now)

--- a/src/synix/search/indexer.py
+++ b/src/synix/search/indexer.py
@@ -37,7 +37,7 @@ class SearchIndex:
         conn.execute("""
             CREATE VIRTUAL TABLE search_index USING fts5(
                 content,
-                artifact_id,
+                label,
                 layer_name,
                 layer_level,
                 metadata
@@ -54,10 +54,10 @@ class SearchIndex:
         # Strip internal build metadata that shouldn't affect search ranking
         search_metadata = {k: v for k, v in artifact.metadata.items() if k not in self._METADATA_INDEX_EXCLUDE}
         conn.execute(
-            "INSERT INTO search_index (content, artifact_id, layer_name, layer_level, metadata) VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO search_index (content, label, layer_name, layer_level, metadata) VALUES (?, ?, ?, ?, ?)",
             (
                 artifact.content,
-                artifact.artifact_id,
+                artifact.label,
                 layer_name,
                 str(layer_level),
                 json.dumps(search_metadata),
@@ -180,7 +180,7 @@ class SearchIndex:
         if layers:
             placeholders = ",".join("?" for _ in layers)
             sql = (
-                f"SELECT content, artifact_id, layer_name, layer_level, metadata, rank "
+                f"SELECT content, label, layer_name, layer_level, metadata, rank "
                 f"FROM search_index "
                 f"WHERE search_index MATCH ? AND layer_name IN ({placeholders}) "
                 f"ORDER BY rank"
@@ -188,7 +188,7 @@ class SearchIndex:
             params = [safe_q, *layers]
         else:
             sql = (
-                "SELECT content, artifact_id, layer_name, layer_level, metadata, rank "
+                "SELECT content, label, layer_name, layer_level, metadata, rank "
                 "FROM search_index "
                 "WHERE search_index MATCH ? "
                 "ORDER BY rank"
@@ -201,15 +201,15 @@ class SearchIndex:
         for row in rows:
             chain: list[str] = []
             if provenance_tracker is not None:
-                records = provenance_tracker.get_chain(row["artifact_id"])
-                chain = [r.artifact_id for r in records]
+                records = provenance_tracker.get_chain(row["label"])
+                chain = [r.label for r in records]
 
             metadata = json.loads(row["metadata"]) if row["metadata"] else {}
 
             results.append(
                 SearchResult(
                     content=row["content"],
-                    artifact_id=row["artifact_id"],
+                    label=row["label"],
                     layer_name=row["layer_name"],
                     layer_level=int(row["layer_level"]),
                     score=abs(row["rank"]),

--- a/src/synix/search/results.py
+++ b/src/synix/search/results.py
@@ -10,7 +10,7 @@ class SearchResult:
     """A single search result with provenance chain."""
 
     content: str
-    artifact_id: str
+    label: str
     layer_name: str
     layer_level: int
     score: float

--- a/src/synix/templates/03-team-report/pipeline.py
+++ b/src/synix/templates/03-team-report/pipeline.py
@@ -43,15 +43,15 @@ class WorkStyleTransform(BaseTransform):
                     ),
                 }
             ],
-            artifact_desc=f"work-style {bio.artifact_id}",
+            artifact_desc=f"work-style {bio.label}",
         )
-        safe_id = bio.artifact_id.replace("t-text-", "")
+        safe_id = bio.label.replace("t-text-", "")
         return [
             Artifact(
-                artifact_id=f"ws-{safe_id}",
+                label=f"ws-{safe_id}",
                 artifact_type="work_style",
                 content=response.content,
-                input_hashes=[bio.content_hash],
+                input_ids=[bio.artifact_id],
                 prompt_id="work_style_v1",
                 model_config=config.get("llm_config"),
             )
@@ -67,7 +67,7 @@ class TeamDynamicsTransform(BaseTransform):
 
     def execute(self, inputs, config):
         client = _get_llm_client(config)
-        profiles = "\n\n".join(f"- {a.artifact_id}: {a.content}" for a in sorted(inputs, key=lambda a: a.artifact_id))
+        profiles = "\n\n".join(f"- {a.label}: {a.content}" for a in sorted(inputs, key=lambda a: a.label))
         response = _logged_complete(
             client,
             config,
@@ -87,10 +87,10 @@ class TeamDynamicsTransform(BaseTransform):
         )
         return [
             Artifact(
-                artifact_id="team-dynamics",
+                label="team-dynamics",
                 artifact_type="team_dynamics",
                 content=response.content,
-                input_hashes=[a.content_hash for a in inputs],
+                input_ids=[a.artifact_id for a in inputs],
                 prompt_id="team_dynamics_v1",
                 model_config=config.get("llm_config"),
             )
@@ -132,10 +132,10 @@ class FinalReportTransform(BaseTransform):
         )
         return [
             Artifact(
-                artifact_id="final-report",
+                label="final-report",
                 artifact_type="final_report",
                 content=response.content,
-                input_hashes=[a.content_hash for a in inputs],
+                input_ids=[a.artifact_id for a in inputs],
                 prompt_id="final_report_v1",
                 model_config=config.get("llm_config"),
             )
@@ -160,7 +160,7 @@ class MaxLengthValidator(BaseValidator):
                         violation_type="max_length",
                         severity="error",
                         message=f"Content is {len(a.content)} chars (max {max_chars})",
-                        artifact_id=a.artifact_id,
+                        label=a.label,
                         field="content",
                     )
                 )

--- a/templates/01-chatbot-export-synthesis/golden/search.stderr.txt
+++ b/templates/01-chatbot-export-synthesis/golden/search.stderr.txt
@@ -1,0 +1,33 @@
+Traceback (most recent call last):
+  File "/home/mark/synix/.venv/bin/synix", line 10, in <module>
+    sys.exit(cli())
+             ~~~^^
+  File "/home/mark/synix/src/synix/cli/main.py", line 73, in cli
+    main()
+    ~~~~^^
+  File "/home/mark/synix/.venv/lib/python3.13/site-packages/click/core.py", line 1485, in __call__
+    return self.main(*args, **kwargs)
+           ~~~~~~~~~^^^^^^^^^^^^^^^^^
+  File "/home/mark/synix/.venv/lib/python3.13/site-packages/click/core.py", line 1406, in main
+    rv = self.invoke(ctx)
+  File "/home/mark/synix/.venv/lib/python3.13/site-packages/click/core.py", line 1873, in invoke
+    return _process_result(sub_ctx.command.invoke(sub_ctx))
+                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
+  File "/home/mark/synix/.venv/lib/python3.13/site-packages/click/core.py", line 1269, in invoke
+    return ctx.invoke(self.callback, **ctx.params)
+           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/mark/synix/.venv/lib/python3.13/site-packages/click/core.py", line 824, in invoke
+    return callback(*args, **kwargs)
+  File "/home/mark/synix/src/synix/cli/search_commands.py", line 90, in search
+    results = projection.query(
+        query,
+        layers=layer_filter,
+        provenance_tracker=provenance,
+    )
+  File "/home/mark/synix/src/synix/search/indexer.py", line 399, in query
+    return index.query(q, layers=layers, provenance_tracker=provenance_tracker)
+           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/mark/synix/src/synix/search/indexer.py", line 198, in query
+    rows = conn.execute(sql, params).fetchall()
+           ~~~~~~~~~~~~^^^^^^^^^^^^^
+sqlite3.OperationalError: no such column: label

--- a/templates/01-chatbot-export-synthesis/golden/search.stdout.txt
+++ b/templates/01-chatbot-export-synthesis/golden/search.stdout.txt
@@ -29,7 +29,7 @@ Search results for: "docker containers" (keyword mode)
 │                                                                                                                      │
 │  ...                                                                                                                 │
 │                                                                                                                      │
-│  Artifact: ep-423ed14b-dda3-4f89-938b-76152356aca6  Score: 2.53  Mode: keyword                                       │
+│  Label: ep-423ed14b-dda3-4f89-938b-76152356aca6  Score: 2.53  Mode: keyword                                          │
 │                                                                                                                      │
 ╰────────────────────────────────────────────────────── Result 1 ──────────────────────────────────────────────────────╯
 ep-423ed14b-dda3-4f89-938b-76152356aca6
@@ -82,7 +82,7 @@ ep-423ed14b-dda3-4f89-938b-76152356aca6
 │  appeared to be designing infrastructure for a multi-tenant SaaS or similar platform requiring scalable, manageable  │
 │  instance deployment.                                                                                                │
 │                                                                                                                      │
-│  Artifact: ep-6866d714-5cd0-800c-b936-80080a9e36d6  Score: 2.43  Mode: keyword                                       │
+│  Label: ep-6866d714-5cd0-800c-b936-80080a9e36d6  Score: 2.43  Mode: keyword                                          │
 │                                                                                                                      │
 ╰────────────────────────────────────────────────────── Result 2 ──────────────────────────────────────────────────────╯
 ep-6866d714-5cd0-800c-b936-80080a9e36d6

--- a/templates/03-team-report/golden/search.stdout.txt
+++ b/templates/03-team-report/golden/search.stdout.txt
@@ -7,7 +7,7 @@ Search results for: "climate dashboard" (keyword mode)
 │  to ingest sensor streams, a data pipeline to clean and aggregate readings, and an intuitive UI that meets WCAG 2.1  │
 │  AA standards. The team has 8 weeks.                                                                                 │
 │                                                                                                                      │
-│  Artifact: t-text-project_brief  Score: 1.55  Mode: keyword                                                          │
+│  Label: t-text-project_brief  Score: 1.55  Mode: keyword                                                             │
 │                                                                                                                      │
 ╰────────────────────────────────────────────────────── Result 1 ──────────────────────────────────────────────────────╯
 t-text-project_brief
@@ -31,7 +31,7 @@ t-text-project_brief
 │                                                                                                                      │
 │  Key Risks & Mitigation: ...                                                                                         │
 │                                                                                                                      │
-│  Artifact: final-report  Score: 1.24  Mode: keyword                                                                  │
+│  Label: final-report  Score: 1.24  Mode: keyword                                                                     │
 │                                                                                                                      │
 ╰────────────────────────────────────────────────────── Result 2 ──────────────────────────────────────────────────────╯
 final-report

--- a/templates/03-team-report/pipeline.py
+++ b/templates/03-team-report/pipeline.py
@@ -43,15 +43,15 @@ class WorkStyleTransform(BaseTransform):
                     ),
                 }
             ],
-            artifact_desc=f"work-style {bio.artifact_id}",
+            artifact_desc=f"work-style {bio.label}",
         )
-        safe_id = bio.artifact_id.replace("t-text-", "")
+        safe_id = bio.label.replace("t-text-", "")
         return [
             Artifact(
-                artifact_id=f"ws-{safe_id}",
+                label=f"ws-{safe_id}",
                 artifact_type="work_style",
                 content=response.content,
-                input_hashes=[bio.content_hash],
+                input_ids=[bio.artifact_id],
                 prompt_id="work_style_v1",
                 model_config=config.get("llm_config"),
             )
@@ -67,7 +67,7 @@ class TeamDynamicsTransform(BaseTransform):
 
     def execute(self, inputs, config):
         client = _get_llm_client(config)
-        profiles = "\n\n".join(f"- {a.artifact_id}: {a.content}" for a in sorted(inputs, key=lambda a: a.artifact_id))
+        profiles = "\n\n".join(f"- {a.label}: {a.content}" for a in sorted(inputs, key=lambda a: a.label))
         response = _logged_complete(
             client,
             config,
@@ -87,10 +87,10 @@ class TeamDynamicsTransform(BaseTransform):
         )
         return [
             Artifact(
-                artifact_id="team-dynamics",
+                label="team-dynamics",
                 artifact_type="team_dynamics",
                 content=response.content,
-                input_hashes=[a.content_hash for a in inputs],
+                input_ids=[a.artifact_id for a in inputs],
                 prompt_id="team_dynamics_v1",
                 model_config=config.get("llm_config"),
             )
@@ -132,10 +132,10 @@ class FinalReportTransform(BaseTransform):
         )
         return [
             Artifact(
-                artifact_id="final-report",
+                label="final-report",
                 artifact_type="final_report",
                 content=response.content,
-                input_hashes=[a.content_hash for a in inputs],
+                input_ids=[a.artifact_id for a in inputs],
                 prompt_id="final_report_v1",
                 model_config=config.get("llm_config"),
             )
@@ -160,7 +160,7 @@ class MaxLengthValidator(BaseValidator):
                         violation_type="max_length",
                         severity="error",
                         message=f"Content is {len(a.content)} chars (max {max_chars})",
-                        artifact_id=a.artifact_id,
+                        label=a.label,
                         field="content",
                     )
                 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def sample_artifacts():
     """Pre-built artifacts for testing downstream modules."""
     return [
         Artifact(
-            artifact_id="t-chatgpt-conv001",
+            label="t-chatgpt-conv001",
             artifact_type="transcript",
             content="user: What is ML?\n\nassistant: Machine learning is...\n\n",
             metadata={
@@ -37,7 +37,7 @@ def sample_artifacts():
             },
         ),
         Artifact(
-            artifact_id="t-chatgpt-conv002",
+            label="t-chatgpt-conv002",
             artifact_type="transcript",
             content="user: Explain Docker\n\nassistant: Docker packages apps...\n\n",
             metadata={
@@ -49,7 +49,7 @@ def sample_artifacts():
             },
         ),
         Artifact(
-            artifact_id="t-claude-conv003",
+            label="t-claude-conv003",
             artifact_type="transcript",
             content="user: What is Rust ownership?\n\nassistant: Rust's ownership...\n\n",
             metadata={
@@ -61,10 +61,10 @@ def sample_artifacts():
             },
         ),
         Artifact(
-            artifact_id="ep-conv001",
+            label="ep-conv001",
             artifact_type="episode",
             content="In this conversation, the user discussed machine learning fundamentals...",
-            input_hashes=["sha256:abc123"],
+            input_ids=["sha256:abc123"],
             prompt_id="episode_summary_v1",
             metadata={
                 "source_conversation_id": "conv001",
@@ -72,10 +72,10 @@ def sample_artifacts():
             },
         ),
         Artifact(
-            artifact_id="ep-conv002",
+            label="ep-conv002",
             artifact_type="episode",
             content="The user asked about Docker containerization...",
-            input_hashes=["sha256:def456"],
+            input_ids=["sha256:def456"],
             prompt_id="episode_summary_v1",
             metadata={
                 "source_conversation_id": "conv002",

--- a/tests/e2e/test_demo_2_startup.py
+++ b/tests/e2e/test_demo_2_startup.py
@@ -405,13 +405,11 @@ class TestDT2ParallelPaths:
 
         # The core artifacts should differ because they were synthesized from
         # different level-2 inputs (monthly rollups vs topical rollups).
-        # Even with mocked LLM, the input_hashes differ, so they get rebuilt.
+        # Even with mocked LLM, the input_ids differ, so they get rebuilt.
         artifact_diff = diff_artifact(core_a, core_b)
 
-        # Core was rebuilt, so at minimum input_hashes differ (different parents)
-        assert core_a.input_hashes != core_b.input_hashes, (
-            "Core input_hashes should differ between monthly and topical paths"
-        )
+        # Core was rebuilt, so at minimum input_ids differ (different parents)
+        assert core_a.input_ids != core_b.input_ids, "Core input_ids should differ between monthly and topical paths"
 
         # Context doc should also reflect the rebuild (content may or may not differ
         # with mocked LLM, but the file was rewritten)

--- a/tests/e2e/test_demo_3_incident.py
+++ b/tests/e2e/test_demo_3_incident.py
@@ -508,12 +508,12 @@ class TestDT3MergeTransform:
         assert len(chain) >= 1, "Provenance chain should not be empty"
 
         # The chain should reach transcript-level artifacts
-        chain_artifact_ids = {rec.artifact_id for rec in chain}
+        chain_artifact_ids = {rec.label for rec in chain}
         # Also collect all parent IDs referenced in the chain
         all_referenced_ids: set[str] = set()
         for rec in chain:
-            all_referenced_ids.add(rec.artifact_id)
-            all_referenced_ids.update(rec.parent_artifact_ids)
+            all_referenced_ids.add(rec.label)
+            all_referenced_ids.update(rec.parent_labels)
 
         # Verify that some of the referenced IDs are transcript-level artifacts
         transcript_ids_in_chain = {

--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -23,9 +23,9 @@ def assert_artifact_exists(store, step: str, record_id: str) -> None:
         record_id: The artifact ID or a substring to match.
     """
     artifacts = store.list_artifacts(step)
-    matching = [a for a in artifacts if record_id in a.artifact_id]
+    matching = [a for a in artifacts if record_id in a.label]
     assert matching, (
-        f"No artifact matching '{record_id}' found in step '{step}'. Available: {[a.artifact_id for a in artifacts]}"
+        f"No artifact matching '{record_id}' found in step '{step}'. Available: {[a.label for a in artifacts]}"
     )
 
 
@@ -77,7 +77,7 @@ def assert_provenance_chain(provenance_tracker, artifact_id: str, expected_chain
         expected_chain: List of artifact IDs expected in the chain (in any order).
     """
     chain = provenance_tracker.get_chain(artifact_id)
-    chain_ids = [r.artifact_id for r in chain]
+    chain_ids = [r.label for r in chain]
     for expected_id in expected_chain:
         assert any(expected_id in cid for cid in chain_ids), (
             f"Expected '{expected_id}' in provenance chain for '{artifact_id}'. Actual chain: {chain_ids}"
@@ -106,7 +106,7 @@ def assert_search_returns(
         top_k: Number of top results to check.
     """
     results = search_fn(query, index_name=index_name, top_k=top_k)
-    result_ids = [r.artifact_id for r in results[:top_k]]
+    result_ids = [r.label for r in results[:top_k]]
     for expected_id in expected_ids:
         assert any(expected_id in rid for rid in result_ids), (
             f"Expected '{expected_id}' in search results for query '{query}' (index: {index_name}). Got: {result_ids}"
@@ -131,8 +131,8 @@ def assert_search_indexes_are_independent(
     """
     results_a = search_fn(query, index_name=index_a, top_k=20)
     results_b = search_fn(query, index_name=index_b, top_k=20)
-    ids_a = {r.artifact_id for r in results_a}
-    ids_b = {r.artifact_id for r in results_b}
+    ids_a = {r.label for r in results_a}
+    ids_b = {r.label for r in results_b}
     overlap = ids_a & ids_b
     assert not overlap, (
         f"Search indexes '{index_a}' and '{index_b}' share artifact IDs: {overlap}. Indexes should be independent."
@@ -258,11 +258,11 @@ def assert_steps_share_sources(store, step_a: str, step_b: str) -> None:
     # Collect all input hashes referenced by each step
     hashes_a = set()
     for a in artifacts_a:
-        hashes_a.update(a.input_hashes)
+        hashes_a.update(a.input_ids)
 
     hashes_b = set()
     for b in artifacts_b:
-        hashes_b.update(b.input_hashes)
+        hashes_b.update(b.input_ids)
 
     assert hashes_a == hashes_b, (
         f"Steps '{step_a}' and '{step_b}' reference different source hashes. "
@@ -279,8 +279,8 @@ def assert_steps_have_distinct_artifacts(store, step_a: str, step_b: str) -> Non
         step_a: First step name.
         step_b: Second step name.
     """
-    ids_a = {a.artifact_id for a in store.list_artifacts(step_a)}
-    ids_b = {a.artifact_id for a in store.list_artifacts(step_b)}
+    ids_a = {a.label for a in store.list_artifacts(step_a)}
+    ids_b = {a.label for a in store.list_artifacts(step_b)}
     overlap = ids_a & ids_b
     assert not overlap, f"Steps '{step_a}' and '{step_b}' share artifact IDs: {overlap}. Expected distinct artifacts."
 

--- a/tests/integration/test_config_change.py
+++ b/tests/integration/test_config_change.py
@@ -175,7 +175,7 @@ class TestConfigChange:
 
         index1 = SearchIndex(build_dir / "search.db")
         results1 = index1.query("programming")
-        ids1 = {r.artifact_id for r in results1}
+        ids1 = {r.label for r in results1}
         index1.close()
 
         topical = _topical_pipeline(build_dir)
@@ -183,7 +183,7 @@ class TestConfigChange:
 
         index2 = SearchIndex(build_dir / "search.db")
         results2 = index2.query("programming")
-        ids2 = {r.artifact_id for r in results2}
+        ids2 = {r.label for r in results2}
         index2.close()
 
         # The rollup artifact IDs should differ (monthly-* vs topic-*)

--- a/tests/integration/test_pipeline_run.py
+++ b/tests/integration/test_pipeline_run.py
@@ -131,14 +131,14 @@ class TestFullPipelineRun:
         # Episodes should have provenance pointing to transcripts
         episodes = store.list_artifacts("episodes")
         for ep in episodes:
-            parents = provenance.get_parents(ep.artifact_id)
-            assert len(parents) > 0, f"Episode {ep.artifact_id} has no provenance parents"
+            parents = provenance.get_parents(ep.label)
+            assert len(parents) > 0, f"Episode {ep.label} has no provenance parents"
 
         # Core should have provenance
         core = store.list_artifacts("core")
         for c in core:
-            parents = provenance.get_parents(c.artifact_id)
-            assert len(parents) > 0, f"Core {c.artifact_id} has no provenance parents"
+            parents = provenance.get_parents(c.label)
+            assert len(parents) > 0, f"Core {c.label} has no provenance parents"
 
     def test_search_returns_results_after_run(self, pipeline_obj, source_dir, build_dir, mock_llm):
         """Pipeline run → search works."""

--- a/tests/integration/test_projections.py
+++ b/tests/integration/test_projections.py
@@ -113,7 +113,7 @@ class TestProjections:
         assert len(chain) > 0
 
         # The chain should include the core artifact
-        chain_ids = [r.artifact_id for r in chain]
+        chain_ids = [r.label for r in chain]
         assert "core-memory" in chain_ids
 
         # Should trace through monthly rollups

--- a/tests/unit/test_artifact_store.py
+++ b/tests/unit/test_artifact_store.py
@@ -13,7 +13,7 @@ class TestArtifactStore:
         """Save artifact, load by ID, content matches."""
         store = ArtifactStore(tmp_build_dir)
         artifact = Artifact(
-            artifact_id="t-chatgpt-conv001",
+            label="t-chatgpt-conv001",
             artifact_type="transcript",
             content="Hello, world!",
             metadata={"source": "chatgpt"},
@@ -22,7 +22,7 @@ class TestArtifactStore:
 
         loaded = store.load_artifact("t-chatgpt-conv001")
         assert loaded is not None
-        assert loaded.artifact_id == "t-chatgpt-conv001"
+        assert loaded.label == "t-chatgpt-conv001"
         assert loaded.artifact_type == "transcript"
         assert loaded.content == "Hello, world!"
         assert loaded.metadata == {"source": "chatgpt"}
@@ -39,7 +39,7 @@ class TestArtifactStore:
         # 2 transcripts
         for i in range(2):
             store.save_artifact(
-                Artifact(artifact_id=f"t-{i}", artifact_type="transcript", content=f"transcript {i}"),
+                Artifact(label=f"t-{i}", artifact_type="transcript", content=f"transcript {i}"),
                 layer_name="transcripts",
                 layer_level=0,
             )
@@ -47,14 +47,14 @@ class TestArtifactStore:
         # 2 episodes
         for i in range(2):
             store.save_artifact(
-                Artifact(artifact_id=f"ep-{i}", artifact_type="episode", content=f"episode {i}"),
+                Artifact(label=f"ep-{i}", artifact_type="episode", content=f"episode {i}"),
                 layer_name="episodes",
                 layer_level=1,
             )
 
         # 1 core
         store.save_artifact(
-            Artifact(artifact_id="core-memory", artifact_type="core_memory", content="core"),
+            Artifact(label="core-memory", artifact_type="core_memory", content="core"),
             layer_name="core",
             layer_level=3,
         )
@@ -68,26 +68,26 @@ class TestArtifactStore:
         """Save artifact, hash is SHA256 of content."""
         store = ArtifactStore(tmp_build_dir)
         content = "Test content for hashing"
-        artifact = Artifact(artifact_id="hash-test", artifact_type="transcript", content=content)
+        artifact = Artifact(label="hash-test", artifact_type="transcript", content=content)
 
         store.save_artifact(artifact, layer_name="transcripts", layer_level=0)
 
         expected_hash = f"sha256:{hashlib.sha256(content.encode()).hexdigest()}"
         loaded = store.load_artifact("hash-test")
         assert loaded is not None
-        assert loaded.content_hash == expected_hash
-        assert store.get_content_hash("hash-test") == expected_hash
+        assert loaded.artifact_id == expected_hash
+        assert store.get_artifact_id("hash-test") == expected_hash
 
     def test_manifest_persistence(self, tmp_build_dir):
         """Save artifacts, create new store instance from same dir, manifest intact."""
         store1 = ArtifactStore(tmp_build_dir)
         store1.save_artifact(
-            Artifact(artifact_id="persist-1", artifact_type="transcript", content="persisted"),
+            Artifact(label="persist-1", artifact_type="transcript", content="persisted"),
             layer_name="transcripts",
             layer_level=0,
         )
         store1.save_artifact(
-            Artifact(artifact_id="persist-2", artifact_type="episode", content="also persisted"),
+            Artifact(label="persist-2", artifact_type="episode", content="also persisted"),
             layer_name="episodes",
             layer_level=1,
         )
@@ -106,14 +106,14 @@ class TestArtifactStore:
         store = ArtifactStore(tmp_build_dir)
 
         store.save_artifact(
-            Artifact(artifact_id="overwrite-me", artifact_type="transcript", content="version 1"),
+            Artifact(label="overwrite-me", artifact_type="transcript", content="version 1"),
             layer_name="transcripts",
             layer_level=0,
         )
-        original_hash = store.get_content_hash("overwrite-me")
+        original_hash = store.get_artifact_id("overwrite-me")
 
         store.save_artifact(
-            Artifact(artifact_id="overwrite-me", artifact_type="transcript", content="version 2"),
+            Artifact(label="overwrite-me", artifact_type="transcript", content="version 2"),
             layer_name="transcripts",
             layer_level=0,
         )
@@ -121,7 +121,7 @@ class TestArtifactStore:
         loaded = store.load_artifact("overwrite-me")
         assert loaded is not None
         assert loaded.content == "version 2"
-        assert store.get_content_hash("overwrite-me") != original_hash
+        assert store.get_artifact_id("overwrite-me") != original_hash
 
 
 class TestResolvePrefix:
@@ -130,17 +130,17 @@ class TestResolvePrefix:
     def _store_with_artifacts(self, tmp_build_dir):
         store = ArtifactStore(tmp_build_dir)
         store.save_artifact(
-            Artifact(artifact_id="t-text-alice", artifact_type="transcript", content="Alice bio"),
+            Artifact(label="t-text-alice", artifact_type="transcript", content="Alice bio"),
             layer_name="bios",
             layer_level=0,
         )
         store.save_artifact(
-            Artifact(artifact_id="t-text-bob", artifact_type="transcript", content="Bob bio"),
+            Artifact(label="t-text-bob", artifact_type="transcript", content="Bob bio"),
             layer_name="bios",
             layer_level=0,
         )
         store.save_artifact(
-            Artifact(artifact_id="ep-alice-001", artifact_type="episode", content="Episode about Alice"),
+            Artifact(label="ep-alice-001", artifact_type="episode", content="Episode about Alice"),
             layer_name="episodes",
             layer_level=1,
         )
@@ -164,14 +164,14 @@ class TestResolvePrefix:
     def test_hash_prefix_unique(self, tmp_build_dir):
         store = self._store_with_artifacts(tmp_build_dir)
         # Get the actual hash of alice and use its first 8 chars
-        full_hash = store.get_content_hash("t-text-alice").removeprefix("sha256:")
+        full_hash = store.get_artifact_id("t-text-alice").removeprefix("sha256:")
         prefix = full_hash[:8]
         resolved = store.resolve_prefix(prefix)
         assert resolved == "t-text-alice"
 
     def test_hash_prefix_with_sha256_prefix(self, tmp_build_dir):
         store = self._store_with_artifacts(tmp_build_dir)
-        full_hash = store.get_content_hash("t-text-bob")
+        full_hash = store.get_artifact_id("t-text-bob")
         # Pass the full "sha256:abcd..." format with a prefix
         short = full_hash[:15]  # "sha256:abcdef12"
         resolved = store.resolve_prefix(short)

--- a/tests/unit/test_cassette.py
+++ b/tests/unit/test_cassette.py
@@ -346,7 +346,7 @@ class TestCassetteEmbeddingWrapper:
             wrapper.embed("unknown text")
 
     def test_content_hash_passthrough(self, tmp_path):
-        """Wrapper preserves content_hash() from real provider."""
+        """Wrapper preserves content_hash() method from real provider."""
         cassette_dir = tmp_path / "cassettes"
         provider = _make_mock_embedding_provider(tmp_path / "build")
         wrapper = CassetteEmbeddingWrapper(provider, "record", cassette_dir)

--- a/tests/unit/test_dag.py
+++ b/tests/unit/test_dag.py
@@ -85,10 +85,10 @@ class TestNeedsRebuild:
         build_fp = compute_build_fingerprint(transform_fp, ["sha256:input1"])
 
         artifact = Artifact(
-            artifact_id="ep-001",
+            label="ep-001",
             artifact_type="episode",
             content="cached content",
-            input_hashes=["sha256:input1"],
+            input_ids=["sha256:input1"],
             prompt_id="ep_v1",
             metadata={"build_fingerprint": build_fp.to_dict()},
         )
@@ -105,10 +105,10 @@ class TestNeedsRebuild:
         old_build_fp = compute_build_fingerprint(old_transform_fp, ["sha256:input1"])
 
         artifact = Artifact(
-            artifact_id="ep-001",
+            label="ep-001",
             artifact_type="episode",
             content="cached content",
-            input_hashes=["sha256:input1"],
+            input_ids=["sha256:input1"],
             prompt_id="ep_v1",
             metadata={"build_fingerprint": old_build_fp.to_dict()},
         )
@@ -126,10 +126,10 @@ class TestNeedsRebuild:
         store = ArtifactStore(tmp_build_dir)
 
         artifact = Artifact(
-            artifact_id="ep-001",
+            label="ep-001",
             artifact_type="episode",
             content="old content",
-            input_hashes=["sha256:input1"],
+            input_ids=["sha256:input1"],
             prompt_id="ep_v1",
         )
         store.save_artifact(artifact, layer_name="episodes", layer_level=1)
@@ -150,10 +150,10 @@ class TestNeedsRebuild:
             components={"transform": "aaa", "inputs": "bbb"},
         )
         artifact = Artifact(
-            artifact_id="ep-001",
+            label="ep-001",
             artifact_type="episode",
             content="old content",
-            input_hashes=["sha256:input1"],
+            input_ids=["sha256:input1"],
             prompt_id="ep_v1",
             metadata={"build_fingerprint": old_fp.to_dict()},
         )
@@ -170,10 +170,10 @@ class TestNeedsRebuild:
         """Without fingerprint, input hash change is detected."""
         store = ArtifactStore(tmp_build_dir)
         artifact = Artifact(
-            artifact_id="ep-001",
+            label="ep-001",
             artifact_type="episode",
             content="cached content",
-            input_hashes=["sha256:input1"],
+            input_ids=["sha256:input1"],
             prompt_id="ep_v1",
         )
         store.save_artifact(artifact, layer_name="episodes", layer_level=1)
@@ -187,8 +187,8 @@ class TestNeedsRebuild:
         assert result is True
         assert "inputs changed" in reasons
 
-    def test_cascade_via_input_hashes(self, tmp_build_dir):
-        """Changing level 1 forces rebuild of 2 and 3 via changed input hashes."""
+    def test_cascade_via_input_ids(self, tmp_build_dir):
+        """Changing level 1 forces rebuild of 2 and 3 via changed input ids."""
         store = ArtifactStore(tmp_build_dir)
         transform_fp = self._make_transform_fp()
 
@@ -196,42 +196,42 @@ class TestNeedsRebuild:
         build_fp1 = compute_build_fingerprint(transform_fp, ["sha256:transcript1"])
         store.save_artifact(
             Artifact(
-                artifact_id="ep-001",
+                label="ep-001",
                 artifact_type="episode",
                 content="episode v1",
-                input_hashes=["sha256:transcript1"],
+                input_ids=["sha256:transcript1"],
                 prompt_id="ep_v1",
                 metadata={"build_fingerprint": build_fp1.to_dict()},
             ),
             layer_name="episodes",
             layer_level=1,
         )
-        ep_hash = store.get_content_hash("ep-001")
+        ep_hash = store.get_artifact_id("ep-001")
 
         # Level 2
         build_fp2 = compute_build_fingerprint(transform_fp, [ep_hash])
         store.save_artifact(
             Artifact(
-                artifact_id="monthly-2025-01",
+                label="monthly-2025-01",
                 artifact_type="rollup",
                 content="monthly v1",
-                input_hashes=[ep_hash],
+                input_ids=[ep_hash],
                 prompt_id="monthly_v1",
                 metadata={"build_fingerprint": build_fp2.to_dict()},
             ),
             layer_name="monthly",
             layer_level=2,
         )
-        monthly_hash = store.get_content_hash("monthly-2025-01")
+        monthly_hash = store.get_artifact_id("monthly-2025-01")
 
         # Level 3
         build_fp3 = compute_build_fingerprint(transform_fp, [monthly_hash])
         store.save_artifact(
             Artifact(
-                artifact_id="core-memory",
+                label="core-memory",
                 artifact_type="core_memory",
                 content="core v1",
-                input_hashes=[monthly_hash],
+                input_ids=[monthly_hash],
                 prompt_id="core_v1",
                 metadata={"build_fingerprint": build_fp3.to_dict()},
             ),
@@ -239,7 +239,7 @@ class TestNeedsRebuild:
             layer_level=3,
         )
 
-        # If episode rebuilds, monthly sees changed input hash
+        # If episode rebuilds, monthly sees changed input id
         new_ep_hash = "sha256:new_episode_hash"
         new_build_fp2 = compute_build_fingerprint(transform_fp, [new_ep_hash])
         result, _ = needs_rebuild("monthly-2025-01", [new_ep_hash], store, current_build_fingerprint=new_build_fp2)

--- a/tests/unit/test_embeddings.py
+++ b/tests/unit/test_embeddings.py
@@ -83,7 +83,7 @@ class TestEmbeddingProvider:
         assert len(result) == 4
         assert all(isinstance(x, float) for x in result)
 
-    def test_embed_caching_by_content_hash(self, provider):
+    def test_embed_caching_by_artifact_id(self, provider):
         """Second call with same text uses cache, not API."""
         result1 = provider.embed("cached text")
         result2 = provider.embed("cached text")
@@ -169,7 +169,7 @@ class TestEmbeddingProvider:
         assert mock_openai_client.embeddings.create.call_count == 0
 
     def test_content_hash_deterministic(self, provider):
-        """content_hash produces consistent results."""
+        """content_hash() produces consistent results."""
         h1 = provider.content_hash("test")
         h2 = provider.content_hash("test")
         h3 = provider.content_hash("different")
@@ -227,7 +227,7 @@ class TestEmbeddingProvider:
         assert len(calls) > 0
         assert calls[-1][1] == 3  # total is always 3
 
-    def test_content_hash_includes_model(self, tmp_build_dir):
+    def test_content_hash_includes_model_in_cache_key(self, tmp_build_dir):
         """Different models produce different cache keys for the same text."""
         config_a = EmbeddingConfig(provider="openai", model="model-a", dimensions=4)
         config_b = EmbeddingConfig(provider="openai", model="model-b", dimensions=4)
@@ -238,7 +238,7 @@ class TestEmbeddingProvider:
         h_b = provider_b.content_hash("same text")
         assert h_a != h_b
 
-    def test_content_hash_includes_provider(self, tmp_build_dir):
+    def test_content_hash_includes_provider_in_cache_key(self, tmp_build_dir):
         """Different providers produce different cache keys for the same text."""
         config_a = EmbeddingConfig(provider="fastembed", model="BAAI/bge-small-en-v1.5")
         config_b = EmbeddingConfig(provider="openai", model="BAAI/bge-small-en-v1.5")
@@ -417,7 +417,7 @@ class TestHybridRetrieverWithEmbeddings:
         for i, content in enumerate(contents):
             index.insert(
                 Artifact(
-                    artifact_id=f"ep-{i:03d}",
+                    label=f"ep-{i:03d}",
                     artifact_type="episode",
                     content=content,
                     metadata={"layer_name": "episodes"},

--- a/tests/unit/test_fix_cli.py
+++ b/tests/unit/test_fix_cli.py
@@ -101,13 +101,13 @@ class TestFixCommand:
 
         # Save an artifact with original content
         art = Artifact(
-            artifact_id="ep-1",
+            label="ep-1",
             artifact_type="episode",
             content="SSN: 123-45-6789",
             metadata={"layer_name": "episodes"},
         )
         store.save_artifact(art, "episodes", 1)
-        original_hash = store.get_content_hash("ep-1")
+        original_hash = store.get_artifact_id("ep-1")
 
         # Persist a violation against the original hash
         queue = ViolationQueue.load(build_dir)
@@ -116,9 +116,9 @@ class TestFixCommand:
                 violation_type="pii",
                 severity="warning",
                 message="PII detected (ssn)",
-                artifact_id="ep-1",
+                label="ep-1",
                 field="content",
-                metadata={"content_hash": original_hash},
+                metadata={"artifact_id": original_hash},
                 violation_id="test-vid-1",
             )
         )
@@ -129,7 +129,7 @@ class TestFixCommand:
 
         # "Rebuild" the artifact with different content
         art2 = Artifact(
-            artifact_id="ep-1",
+            label="ep-1",
             artifact_type="episode",
             content="No PII here, all clean.",
             metadata={"layer_name": "episodes"},
@@ -160,13 +160,13 @@ class TestFixCommand:
 
         store = ArtifactStore(build_dir)
         art = Artifact(
-            artifact_id="ep-1",
+            label="ep-1",
             artifact_type="episode",
             content="SSN: 123-45-6789",
             metadata={"layer_name": "episodes"},
         )
         store.save_artifact(art, "episodes", 1)
-        content_hash = store.get_content_hash("ep-1")
+        content_hash = store.get_artifact_id("ep-1")
 
         queue = ViolationQueue.load(build_dir)
         queue.upsert(
@@ -174,9 +174,9 @@ class TestFixCommand:
                 violation_type="pii",
                 severity="warning",
                 message="PII detected",
-                artifact_id="ep-1",
+                label="ep-1",
                 field="content",
-                metadata={"content_hash": content_hash},
+                metadata={"artifact_id": content_hash},
                 violation_id="test-vid-2",
             )
         )

--- a/tests/unit/test_flat_file.py
+++ b/tests/unit/test_flat_file.py
@@ -13,7 +13,7 @@ class TestFlatFileProjection:
         projection = FlatFileProjection()
 
         artifact = Artifact(
-            artifact_id="core-memory",
+            label="core-memory",
             artifact_type="core_memory",
             content="## Identity\nMark is a software engineer.",
         )
@@ -28,7 +28,7 @@ class TestFlatFileProjection:
 
         content = "## Identity\nMark is a software engineer.\n\n## Current Focus\nBuilding Synix."
         artifact = Artifact(
-            artifact_id="core-memory",
+            label="core-memory",
             artifact_type="core_memory",
             content=content,
         )
@@ -42,8 +42,8 @@ class TestFlatFileProjection:
         projection = FlatFileProjection()
 
         artifacts = [
-            Artifact(artifact_id="core-1", artifact_type="core_memory", content="## Section One\nFirst part."),
-            Artifact(artifact_id="core-2", artifact_type="core_memory", content="## Section Two\nSecond part."),
+            Artifact(label="core-1", artifact_type="core_memory", content="## Section One\nFirst part."),
+            Artifact(label="core-2", artifact_type="core_memory", content="## Section Two\nSecond part."),
         ]
 
         projection.materialize(artifacts, {"output_path": str(output_path)})

--- a/tests/unit/test_llm_client.py
+++ b/tests/unit/test_llm_client.py
@@ -675,7 +675,7 @@ class TestLLMClientBackwardCompat:
         assert len(results) == 1
         ep = results[0]
         assert ep.artifact_type == "episode"
-        assert ep.content_hash.startswith("sha256:")
+        assert ep.artifact_id.startswith("sha256:")
         assert len(mock_llm) == 1  # LLM was called exactly once
 
     def test_pipeline_llm_config_without_provider(self, mock_llm, sample_artifacts):

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -76,12 +76,12 @@ class TestChatGPTParsing:
     def test_chatgpt_artifact_ids_prefixed(self, chatgpt_fixture_path):
         """All artifact IDs have t-chatgpt- prefix."""
         artifacts = parse_chatgpt(chatgpt_fixture_path)
-        assert all(a.artifact_id.startswith("t-chatgpt-") for a in artifacts)
+        assert all(a.label.startswith("t-chatgpt-") for a in artifacts)
 
-    def test_chatgpt_content_hash_computed(self, chatgpt_fixture_path):
-        """Content hash is auto-computed by Artifact.__post_init__."""
+    def test_chatgpt_artifact_id_computed(self, chatgpt_fixture_path):
+        """Artifact ID is auto-computed by Artifact.__post_init__."""
         artifacts = parse_chatgpt(chatgpt_fixture_path)
-        assert all(a.content_hash.startswith("sha256:") for a in artifacts)
+        assert all(a.artifact_id.startswith("sha256:") for a in artifacts)
 
     def test_chatgpt_regeneration_follows_current_node(self, tmp_path):
         """When a response is regenerated, current_node selects the active branch."""
@@ -262,20 +262,18 @@ class TestClaudeParsing:
     def test_claude_artifact_ids_prefixed(self, claude_fixture_path):
         """All artifact IDs have t-claude- prefix."""
         artifacts = parse_claude(claude_fixture_path)
-        assert all(a.artifact_id.startswith("t-claude-") for a in artifacts)
+        assert all(a.label.startswith("t-claude-") for a in artifacts)
 
     def test_claude_sender_normalized(self, claude_fixture_path):
         """Claude 'human' sender is normalized to 'user' in transcripts."""
         artifacts = parse_claude(claude_fixture_path)
         for artifact in artifacts:
-            assert "human:" not in artifact.content, (
-                f"Artifact {artifact.artifact_id} contains un-normalized 'human:' sender"
-            )
+            assert "human:" not in artifact.content, f"Artifact {artifact.label} contains un-normalized 'human:' sender"
             # All user messages should use "user:" prefix
             lines = artifact.content.strip().split("\n\n")
             for line in lines:
                 role = line.split(":")[0]
-                assert role in ("user", "assistant"), f"Unexpected role '{role}' in artifact {artifact.artifact_id}"
+                assert role in ("user", "assistant"), f"Unexpected role '{role}' in artifact {artifact.label}"
 
 
 class TestMixedSources:
@@ -286,7 +284,7 @@ class TestMixedSources:
         chatgpt_artifacts = parse_chatgpt(chatgpt_fixture_path)
         claude_artifacts = parse_claude(claude_fixture_path)
 
-        all_ids = [a.artifact_id for a in chatgpt_artifacts + claude_artifacts]
+        all_ids = [a.label for a in chatgpt_artifacts + claude_artifacts]
         assert len(all_ids) == len(set(all_ids)), "Artifact ID collision detected"
 
     def test_mixed_sources_correct_total(self, chatgpt_fixture_path, claude_fixture_path):

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -323,12 +323,12 @@ class TestPlanBuildPartialRebuild:
             assert episode_step.status == "rebuild"
 
             # Monthly and core should also need rebuild due to cascade
-            # (their existing artifacts have input_hashes from old episodes,
-            # but we can't predict the new hashes, so the layer won't be fully cached)
+            # (their existing artifacts have input_ids from old episodes,
+            # but we can't predict the new artifact_ids, so the layer won't be fully cached)
             monthly_step = next(s for s in plan.steps if s.name == "monthly")
             # Monthly might show as cached because episodes' *existing* artifacts
             # (the old cached ones) still match. The real cascade happens at run time
-            # when new episode artifacts produce new content_hashes.
+            # when new episode artifacts produce new artifact_ids.
             # However, if episodes rebuild, the plan should detect that downstream
             # layers cannot be fully cached since episode artifacts in the store
             # are stale (prompt mismatch). Let's verify the plan at least flags

--- a/tests/unit/test_projections_first_class.py
+++ b/tests/unit/test_projections_first_class.py
@@ -196,13 +196,13 @@ class TestLayerProjectionChain:
         """Fake episode artifacts with the metadata the index needs."""
         return [
             Artifact(
-                artifact_id="ep-conv001",
+                label="ep-conv001",
                 artifact_type="episode",
                 content="Discussion about Python programming and web development.",
                 metadata={"layer_name": "episodes", "layer_level": 1, "date": "2024-03", "title": "Python chat"},
             ),
             Artifact(
-                artifact_id="ep-conv002",
+                label="ep-conv002",
                 artifact_type="episode",
                 content="Machine learning model training and evaluation.",
                 metadata={"layer_name": "episodes", "layer_level": 1, "date": "2024-03", "title": "ML chat"},
@@ -213,7 +213,7 @@ class TestLayerProjectionChain:
     def monthly_artifacts(self):
         return [
             Artifact(
-                artifact_id="monthly-2024-03",
+                label="monthly-2024-03",
                 artifact_type="rollup",
                 content="March themes: programming and ML.",
                 metadata={"layer_name": "monthly", "layer_level": 2, "month": "2024-03"},
@@ -224,7 +224,7 @@ class TestLayerProjectionChain:
     def core_artifacts(self):
         return [
             Artifact(
-                artifact_id="core-memory",
+                label="core-memory",
                 artifact_type="core_memory",
                 content="## Identity\nSoftware engineer focused on AI.",
                 metadata={"layer_name": "core", "layer_level": 3},
@@ -369,7 +369,7 @@ class TestLayerProjectionChain:
         # Only after core layer is present should the flat file materialize
         layer_artifacts["core"] = [
             Artifact(
-                artifact_id="core-memory",
+                label="core-memory",
                 artifact_type="core_memory",
                 content="## Identity\nSoftware engineer.",
                 metadata={"layer_name": "core", "layer_level": 3},

--- a/tests/unit/test_provenance.py
+++ b/tests/unit/test_provenance.py
@@ -10,8 +10,8 @@ class TestProvenanceTracker:
         """Record provenance, get_parents returns correct IDs."""
         tracker = ProvenanceTracker(tmp_build_dir)
         tracker.record(
-            artifact_id="ep-conv001",
-            parent_ids=["t-chatgpt-conv001"],
+            label="ep-conv001",
+            parent_labels=["t-chatgpt-conv001"],
             prompt_id="episode_summary_v1",
             model_config={"model": "claude-sonnet-4-20250514"},
         )
@@ -27,16 +27,16 @@ class TestProvenanceTracker:
         tracker = ProvenanceTracker(tmp_build_dir)
 
         # transcript has no parents (root)
-        tracker.record("t-001", parent_ids=[])
+        tracker.record("t-001", parent_labels=[])
         # episode depends on transcript
-        tracker.record("ep-001", parent_ids=["t-001"], prompt_id="episode_v1")
+        tracker.record("ep-001", parent_labels=["t-001"], prompt_id="episode_v1")
         # monthly depends on episode
-        tracker.record("monthly-2025-01", parent_ids=["ep-001"], prompt_id="monthly_v1")
+        tracker.record("monthly-2025-01", parent_labels=["ep-001"], prompt_id="monthly_v1")
         # core depends on monthly
-        tracker.record("core-memory", parent_ids=["monthly-2025-01"], prompt_id="core_v1")
+        tracker.record("core-memory", parent_labels=["monthly-2025-01"], prompt_id="core_v1")
 
         chain = tracker.get_chain("core-memory")
-        chain_ids = [r.artifact_id for r in chain]
+        chain_ids = [r.label for r in chain]
 
         assert "core-memory" in chain_ids
         assert "monthly-2025-01" in chain_ids
@@ -50,15 +50,15 @@ class TestProvenanceTracker:
 
         # 5 episodes, each from a transcript
         for i in range(5):
-            tracker.record(f"t-{i}", parent_ids=[])
-            tracker.record(f"ep-{i}", parent_ids=[f"t-{i}"], prompt_id="episode_v1")
+            tracker.record(f"t-{i}", parent_labels=[])
+            tracker.record(f"ep-{i}", parent_labels=[f"t-{i}"], prompt_id="episode_v1")
 
         # Monthly rollup depends on all 5 episodes
         episode_ids = [f"ep-{i}" for i in range(5)]
-        tracker.record("monthly-2025-01", parent_ids=episode_ids, prompt_id="monthly_v1")
+        tracker.record("monthly-2025-01", parent_labels=episode_ids, prompt_id="monthly_v1")
 
         chain = tracker.get_chain("monthly-2025-01")
-        chain_ids = {r.artifact_id for r in chain}
+        chain_ids = {r.label for r in chain}
 
         # Should include: monthly + 5 episodes + 5 transcripts = 11
         assert "monthly-2025-01" in chain_ids
@@ -72,7 +72,7 @@ class TestProvenanceTracker:
         tracker1 = ProvenanceTracker(tmp_build_dir)
         tracker1.record(
             "ep-001",
-            parent_ids=["t-001", "t-002"],
+            parent_labels=["t-001", "t-002"],
             prompt_id="episode_v1",
             model_config={"model": "claude-sonnet-4-20250514"},
         )

--- a/tests/unit/test_search_cli_extensions.py
+++ b/tests/unit/test_search_cli_extensions.py
@@ -29,7 +29,7 @@ def populated_build_dir(tmp_path):
 
     # Transcript artifact
     t1 = Artifact(
-        artifact_id="t-conv001",
+        label="t-conv001",
         artifact_type="transcript",
         content="user: Tell me about machine learning\nassistant: Machine learning is a subset of AI",
         metadata={
@@ -45,7 +45,7 @@ def populated_build_dir(tmp_path):
 
     # Episode artifact
     ep1 = Artifact(
-        artifact_id="ep-conv001",
+        label="ep-conv001",
         artifact_type="episode",
         content="In this conversation about machine learning, the user discussed fundamentals of AI",
         metadata={
@@ -59,7 +59,7 @@ def populated_build_dir(tmp_path):
 
     # Another episode with different customer
     ep2 = Artifact(
-        artifact_id="ep-conv002",
+        label="ep-conv002",
         artifact_type="episode",
         content="Discussion about machine learning applications in healthcare and diagnostics",
         metadata={
@@ -73,7 +73,7 @@ def populated_build_dir(tmp_path):
 
     # Monthly rollup artifact
     m1 = Artifact(
-        artifact_id="monthly-2024-03",
+        label="monthly-2024-03",
         artifact_type="rollup",
         content="In March 2024 the main themes were machine learning and AI development",
         metadata={
@@ -85,10 +85,10 @@ def populated_build_dir(tmp_path):
     store.save_artifact(m1, layer_name="monthly", layer_level=2)
 
     # Record provenance chains
-    provenance.record("t-conv001", parent_ids=[], prompt_id=None)
-    provenance.record("ep-conv001", parent_ids=["t-conv001"], prompt_id="episode_summary_v1")
-    provenance.record("ep-conv002", parent_ids=[], prompt_id="episode_summary_v1")
-    provenance.record("monthly-2024-03", parent_ids=["ep-conv001", "ep-conv002"], prompt_id="monthly_rollup_v1")
+    provenance.record("t-conv001", parent_labels=[], prompt_id=None)
+    provenance.record("ep-conv001", parent_labels=["t-conv001"], prompt_id="episode_summary_v1")
+    provenance.record("ep-conv002", parent_labels=[], prompt_id="episode_summary_v1")
+    provenance.record("monthly-2024-03", parent_labels=["ep-conv001", "ep-conv002"], prompt_id="monthly_rollup_v1")
 
     # Build search index
     db_path = build_dir / "search.db"
@@ -288,7 +288,7 @@ def test_trace_without_provenance_data(runner, tmp_path):
 
     # Create a search index with an artifact that has no provenance
     artifact = Artifact(
-        artifact_id="orphan-001",
+        label="orphan-001",
         artifact_type="episode",
         content="An orphaned artifact about machine learning with no provenance",
         metadata={"layer_name": "episodes"},

--- a/tests/unit/test_shadow_index.py
+++ b/tests/unit/test_shadow_index.py
@@ -14,10 +14,10 @@ from synix import Artifact
 from synix.search.indexer import SearchIndex, SearchIndexProjection, ShadowIndexManager
 
 
-def _make_artifact(artifact_id: str, content: str, layer: str = "episodes") -> Artifact:
+def _make_artifact(label: str, content: str, layer: str = "episodes") -> Artifact:
     """Helper to create a test artifact."""
     return Artifact(
-        artifact_id=artifact_id,
+        label=label,
         artifact_type="episode",
         content=content,
         metadata={"layer_name": layer, "layer_level": 1},
@@ -46,11 +46,11 @@ class TestShadowIndexSwap:
         # Verify data is queryable in the final index
         results = proj.query("machine learning")
         assert len(results) == 1
-        assert results[0].artifact_id == "ep-001"
+        assert results[0].label == "ep-001"
 
         results2 = proj.query("distributed systems")
         assert len(results2) == 1
-        assert results2[0].artifact_id == "ep-002"
+        assert results2[0].label == "ep-002"
 
         proj.close()
 
@@ -108,7 +108,7 @@ class TestShadowIndexSwap:
         verify_index = SearchIndex(old_db_path)
         results = verify_index.query("Rust")
         assert len(results) == 1
-        assert results[0].artifact_id == "old-001"
+        assert results[0].label == "old-001"
 
         # New data should NOT be in the index
         new_results = verify_index.query("New data")
@@ -135,7 +135,7 @@ class TestShadowIndexSwap:
 
         results = proj.query("Python")
         assert len(results) == 1
-        assert results[0].artifact_id == "ep-001"
+        assert results[0].label == "ep-001"
 
         proj.close()
 
@@ -162,7 +162,7 @@ class TestShadowIndexSwap:
         reader = SearchIndex(tmp_build_dir / "search.db")
         results = reader.query("Docker")
         assert len(results) == 1
-        assert results[0].artifact_id == "old-001"
+        assert results[0].label == "old-001"
 
         # New content should NOT be visible in the main index yet
         new_results = reader.query("Kubernetes")
@@ -176,7 +176,7 @@ class TestShadowIndexSwap:
         reader2 = SearchIndex(tmp_build_dir / "search.db")
         new_results2 = reader2.query("Kubernetes")
         assert len(new_results2) == 1
-        assert new_results2[0].artifact_id == "new-001"
+        assert new_results2[0].label == "new-001"
         reader2.close()
 
     def test_rollback_cleans_up_shadow(self, tmp_build_dir):

--- a/tests/unit/test_text_adapter.py
+++ b/tests/unit/test_text_adapter.py
@@ -27,10 +27,10 @@ class TestParseTextPlain:
         assert art.artifact_type == "transcript"
         assert art.metadata["source"] == "text"
 
-    def test_plain_text_artifact_id(self):
-        """Artifact ID uses t-text- prefix with sanitized filename stem."""
+    def test_plain_text_label(self):
+        """Label uses t-text- prefix with sanitized filename stem."""
         artifacts = parse_text(FIXTURES_DIR / "journal.txt")
-        assert artifacts[0].artifact_id == "t-text-journal"
+        assert artifacts[0].label == "t-text-journal"
 
     def test_plain_text_content(self):
         """Content preserves original text."""
@@ -56,10 +56,10 @@ class TestParseTextPlain:
         artifacts = parse_text(FIXTURES_DIR / "journal.txt")
         assert "has_turns" not in artifacts[0].metadata
 
-    def test_plain_text_content_hash(self):
-        """Content hash is auto-computed by Artifact.__post_init__."""
+    def test_plain_text_artifact_id(self):
+        """Artifact ID is auto-computed by Artifact.__post_init__."""
         artifacts = parse_text(FIXTURES_DIR / "journal.txt")
-        assert artifacts[0].content_hash.startswith("sha256:")
+        assert artifacts[0].artifact_id.startswith("sha256:")
 
 
 class TestParseMarkdownFrontmatter:
@@ -106,7 +106,7 @@ class TestParseMarkdownFrontmatter:
     def test_artifact_id_from_filename(self):
         """Artifact ID derived from filename stem."""
         artifacts = parse_text(FIXTURES_DIR / "2025-01-15-meeting-notes.md")
-        assert artifacts[0].artifact_id == "t-text-2025-01-15-meeting-notes"
+        assert artifacts[0].label == "t-text-2025-01-15-meeting-notes"
 
 
 class TestDateInference:
@@ -202,7 +202,7 @@ class TestEdgeCases:
         filepath = tmp_path / "meeting (draft) v2.txt"
         filepath.write_text("Some meeting notes.\n")
         artifacts = parse_text(filepath)
-        art_id = artifacts[0].artifact_id
+        art_id = artifacts[0].label
         assert art_id.startswith("t-text-")
         assert "(" not in art_id
         assert ")" not in art_id
@@ -298,7 +298,7 @@ class TestRegistryBackwardCompat:
         chatgpt_path = Path(__file__).parent.parent / "synix" / "fixtures" / "chatgpt_export.json"
         artifacts = parse_file(chatgpt_path)
         assert len(artifacts) > 0
-        assert all(a.artifact_id.startswith("t-chatgpt-") for a in artifacts)
+        assert all(a.label.startswith("t-chatgpt-") for a in artifacts)
         assert all(a.metadata["source"] == "chatgpt" for a in artifacts)
 
     def test_claude_json_via_registry(self):
@@ -306,7 +306,7 @@ class TestRegistryBackwardCompat:
         claude_path = Path(__file__).parent.parent / "synix" / "fixtures" / "claude_export.json"
         artifacts = parse_file(claude_path)
         assert len(artifacts) > 0
-        assert all(a.artifact_id.startswith("t-claude-") for a in artifacts)
+        assert all(a.label.startswith("t-claude-") for a in artifacts)
         assert all(a.metadata["source"] == "claude" for a in artifacts)
 
     def test_unrecognized_json_returns_empty(self, tmp_path):

--- a/tests/unit/test_transforms.py
+++ b/tests/unit/test_transforms.py
@@ -170,10 +170,10 @@ class TestEpisodeSummaryTransform:
         assert len(results) == 1
         ep = results[0]
         assert ep.artifact_type == "episode"
-        assert ep.artifact_id.startswith("ep-")
+        assert ep.label.startswith("ep-")
         assert ep.prompt_id is not None
         assert ep.prompt_id.startswith("episode_summary_v")
-        assert ep.content_hash.startswith("sha256:")
+        assert ep.artifact_id.startswith("sha256:")
         assert ep.metadata["source_conversation_id"] == transcripts[0].metadata["source_conversation_id"]
 
     def test_episode_summary_multiple_inputs(self, mock_llm, sample_artifacts):
@@ -193,7 +193,7 @@ class TestMonthlyRollupTransform:
         """6 episodes across 2 months → 2 rollups."""
         episodes = [
             Artifact(
-                artifact_id=f"ep-{i}",
+                label=f"ep-{i}",
                 artifact_type="episode",
                 content=f"Episode {i} content about technical topics.",
                 metadata={"date": date, "title": f"Episode {i}"},
@@ -225,7 +225,7 @@ class TestMonthlyRollupTransform:
         """Rollup artifacts have correct type and ID format."""
         episodes = [
             Artifact(
-                artifact_id="ep-1",
+                label="ep-1",
                 artifact_type="episode",
                 content="Content here.",
                 metadata={"date": "2024-03-15", "title": "Test"},
@@ -236,7 +236,7 @@ class TestMonthlyRollupTransform:
 
         assert len(results) == 1
         assert results[0].artifact_type == "rollup"
-        assert results[0].artifact_id == "monthly-2024-03"
+        assert results[0].label == "monthly-2024-03"
 
 
 class TestTopicalRollupTransform:
@@ -246,13 +246,13 @@ class TestTopicalRollupTransform:
         """3 topics configured → 3 topic artifacts."""
         episodes = [
             Artifact(
-                artifact_id="ep-1",
+                label="ep-1",
                 artifact_type="episode",
                 content="Discussion about career and AI projects.",
                 metadata={"date": "2024-03-15", "title": "Career chat"},
             ),
             Artifact(
-                artifact_id="ep-2",
+                label="ep-2",
                 artifact_type="episode",
                 content="Discussion about health and exercise.",
                 metadata={"date": "2024-03-16", "title": "Health chat"},
@@ -271,14 +271,14 @@ class TestTopicalRollupTransform:
 
         assert len(results) == 3
         assert len(mock_llm) == 3
-        topic_ids = {r.artifact_id for r in results}
-        assert topic_ids == {"topic-career", "topic-health", "topic-ai-projects"}
+        topic_labels = {r.label for r in results}
+        assert topic_labels == {"topic-career", "topic-health", "topic-ai-projects"}
 
     def test_topical_rollup_uses_all_episodes_without_search(self, mock_llm):
         """Without search_db_path, all episodes used for each topic."""
         episodes = [
             Artifact(
-                artifact_id=f"ep-{i}",
+                label=f"ep-{i}",
                 artifact_type="episode",
                 content=f"Content {i}",
                 metadata={"date": "2024-03-15", "title": f"Ep {i}"},
@@ -296,8 +296,8 @@ class TestTopicalRollupTransform:
         )
 
         assert len(results) == 1
-        # All 3 episodes should be in input_hashes
-        assert len(results[0].input_hashes) == 3
+        # All 3 episodes should be in input_ids
+        assert len(results[0].input_ids) == 3
 
 
 class TestCoreSynthesisTransform:
@@ -307,7 +307,7 @@ class TestCoreSynthesisTransform:
         """Always produces exactly 1 artifact."""
         rollups = [
             Artifact(
-                artifact_id=f"monthly-2024-0{i}",
+                label=f"monthly-2024-0{i}",
                 artifact_type="rollup",
                 content=f"Rollup for month {i}.",
                 metadata={"month": f"2024-0{i}"},
@@ -319,7 +319,7 @@ class TestCoreSynthesisTransform:
         results = transform.execute(rollups, {"llm_config": {}, "context_budget": 5000})
 
         assert len(results) == 1
-        assert results[0].artifact_id == "core-memory"
+        assert results[0].label == "core-memory"
         assert results[0].artifact_type == "core_memory"
         assert results[0].metadata["context_budget"] == 5000
         assert results[0].metadata["input_count"] == 3
@@ -328,7 +328,7 @@ class TestCoreSynthesisTransform:
         """Core synthesis artifact has a valid prompt_id."""
         rollups = [
             Artifact(
-                artifact_id="monthly-2024-01",
+                label="monthly-2024-01",
                 artifact_type="rollup",
                 content="Rollup content.",
                 metadata={"month": "2024-01"},

--- a/tests/unit/test_validate_cli.py
+++ b/tests/unit/test_validate_cli.py
@@ -122,7 +122,7 @@ class TestValidateCommand:
 
         store = ArtifactStore(build_dir)
         art = Artifact(
-            artifact_id="ep-1",
+            label="ep-1",
             artifact_type="episode",
             content="Email me at user@example.com for details.",
             metadata={"layer_name": "episodes"},
@@ -155,7 +155,7 @@ class TestValidateCommand:
 
         store = ArtifactStore(build_dir)
         art = Artifact(
-            artifact_id="ep-1",
+            label="ep-1",
             artifact_type="episode",
             content="SSN: 123-45-6789",
             metadata={"layer_name": "episodes"},
@@ -181,7 +181,7 @@ class TestValidateCommand:
 
         store = ArtifactStore(build_dir)
         art = Artifact(
-            artifact_id="ep-1",
+            label="ep-1",
             artifact_type="episode",
             content="Credit card: 4111-1111-1111-1111",
             metadata={"layer_name": "episodes"},
@@ -198,7 +198,7 @@ class TestValidateCommand:
 
         store = ArtifactStore(build_dir)
         art = Artifact(
-            artifact_id="ep-1",
+            label="ep-1",
             artifact_type="episode",
             content="Phone: (555) 123-4567",
             metadata={"layer_name": "episodes"},


### PR DESCRIPTION
## Summary

Clarifies the entity model by giving fields semantically accurate names. The old `artifact_id` was a human-readable label (e.g., `ep-conv001`), while `content_hash` was the actual content-addressed identifier — confusing for anyone reading the code.

**Field renames across 74 files:**
- `Artifact.artifact_id` (human name) → `Artifact.label`
- `Artifact.content_hash` (SHA256 hash) → `Artifact.artifact_id`
- `Artifact.input_hashes` → `Artifact.input_ids`
- `ProvenanceRecord.artifact_id` → `ProvenanceRecord.label`
- `ProvenanceRecord.parent_artifact_ids` → `ProvenanceRecord.parent_labels`
- `SearchResult`/`Violation`/`ProvenanceStep`/`FixAction` `.artifact_id` → `.label`
- `ProvenanceTracker.record(parent_ids=)` → `parent_labels=`
- `ArtifactStore.get_content_hash()` → `get_artifact_id()`
- `diff_artifact_by_id()` → `diff_artifact_by_label()`
- Metadata key `source_artifact_ids` → `source_labels`

All 859 tests pass, all 3 demo goldens pass, lint clean.

## Test plan
- [x] `uv run release` passes (lint → sync → test → demos)
- [x] 859 tests pass
- [x] All 3 demo golden comparisons pass
- [x] No remaining references to old field names in src/ or tests/