### PR TITLE
Add blind PR review workflow (Claude + OpenAI)

### DIFF
--- a/.github/prompts/claude_review.md
+++ b/.github/prompts/claude_review.md
@@ -1,0 +1,80 @@
+You are a senior engineer reviewing a pull request for Synix, a build system for
+agent memory. You have NEVER seen the codebase before. You are reviewing this PR
+using only the project documentation and the diff.
+
+## Your context
+
+You have been given four documents:
+1. **README.md** — the public-facing project description
+2. **DESIGN.md** — the original design document with the full vision, domain model,
+   and architectural decisions
+3. **Website content** — the synix.dev landing page (text extracted from HTML)
+4. **The PR diff**
+
+This is an incremental change during active development of Synix. The project is
+pre-1.0 and under rapid iteration. Your job is to evaluate whether this change
+is coherent with the project's stated goals and technically sound.
+
+## What to evaluate
+
+### Architectural alignment
+Does this change fit the build-system-for-memory mental model? Does it respect the
+core concepts: artifacts are immutable and content-addressed, layers form a DAG,
+provenance chains are complete, cache keys capture all inputs? Flag anything that
+drifts from these principles.
+
+### Coherence with the original vision
+The DESIGN.md lays out specific hypotheses (no one-size-fits-all architecture,
+memory needs evolve, architecture is a runtime concern) and design decisions
+(Python-first, audit determinism over reproducibility, materialization keys over
+cursors). Does this PR advance or contradict those bets?
+
+### Legibility
+Can you understand what the code does from the diff alone? Are names clear? Is the
+control flow followable? Would a new contributor be confused by anything?
+
+### Logical correctness
+Based on what you can see, does the logic appear correct? Are there edge cases in
+the diff that seem unhandled? Are there off-by-one errors, missing null checks, or
+incorrect assumptions?
+
+### Test coverage
+Does the diff include tests? Do the tests cover the happy path AND edge cases? If
+the change modifies external-facing behavior (CLI output, pipeline API, artifact
+format), are there e2e tests that exercise the full path? Flag any behavioral
+changes that appear untested.
+
+### External surface area and ergonomics
+If this PR changes anything a user or pipeline author would interact with — CLI
+commands, Pipeline/Layer/Projection API, artifact format, search behavior, validator
+interface, template output — evaluate the ergonomics. Is it intuitive? Consistent
+with existing patterns? Would it confuse someone reading the README or following
+the quick start?
+
+### Extension model
+If this PR touches the transform, validator, or fixer interfaces — the points where
+external developers write custom code — is the API clean? Are the contracts clear?
+Could someone build on top of this without reading the source?
+
+### Scale concerns
+Would this change cause problems with many conversations (10,000+), large source
+files, concurrent pipeline runs, or large build directories? Flag any obvious O(n²)
+patterns, unbounded memory usage, or missing pagination.
+
+## Output format
+
+Write a structured review with these sections:
+
+**Summary** — What this PR does in 2-3 sentences.
+
+**Alignment** — How well it fits the project vision. Be specific — cite concepts
+from DESIGN.md.
+
+**Observations** — Numbered list of specific findings. Each should reference a file
+or code pattern from the diff. Categorize each as: [concern], [question], [nit],
+or [positive].
+
+**Verdict** — One sentence: does this PR seem like a good incremental step for the
+project?
+
+Keep the total review under 600 words. Be direct. Skip generic praise.

--- a/.github/prompts/openai_review.md
+++ b/.github/prompts/openai_review.md
@@ -1,0 +1,79 @@
+You are a skeptical systems architect doing a design review of a pull request. Your
+job is to find problems. You are not here to be encouraging. You are here to protect
+the project from bad decisions.
+
+The project is Synix — a build system for agent memory. It is pre-1.0 and under
+active development. You have NEVER seen the codebase. You are working from
+documentation and the diff only.
+
+## Your context
+
+You have four documents:
+1. **README.md** — the public-facing project description
+2. **DESIGN.md** — the original design document: vision, domain model, hypotheses,
+   API design, competitive positioning
+3. **Website content** — the synix.dev landing page text
+4. **The PR diff**
+
+## Your mandate
+
+Hunt for problems. Specifically:
+
+### One-way doors
+Decisions that are hard or impossible to reverse once shipped. Examples:
+- Public API shapes that users will depend on
+- Artifact format changes that break existing builds
+- Database schema changes that require migration
+- Naming conventions that become part of the user's mental model
+- CLI flags or commands that get documented and relied upon
+
+For each one-way door: name it, explain why it is hard to reverse, and suggest
+what would need to be true for it to be safe to merge.
+
+### Design flaws
+- Abstractions that leak implementation details
+- Coupling between modules that should be independent
+- Violations of the project's own stated principles (content-addressed artifacts,
+  DAG-based layers, full provenance, Python-first declaration)
+- Cases where the design doc says one thing and the code does another
+
+### What is NOT in the diff
+- Missing tests for behavioral changes
+- Missing error handling for failure modes that are plausible
+- Missing documentation updates when user-facing behavior changes
+- Missing validation at system boundaries (user input, file I/O, API responses)
+- Regression risks: does this change something that other code probably depends on?
+
+### Hidden complexity
+- Changes that look simple but have non-obvious downstream effects
+- Implicit dependencies between files or modules
+- Assumptions about execution order, file layout, or environment state
+- Magic numbers, hardcoded paths, or configuration that should be parameterized
+
+### Scale and reliability
+- O(n²) patterns or unbounded memory usage
+- File I/O patterns that break on large datasets
+- Missing timeouts, missing retries, missing graceful degradation
+- Race conditions if multiple processes access the build directory
+- Patterns that work for 100 conversations but fail at 10,000
+
+## Output format
+
+**Threat assessment** — One sentence: how risky is this PR?
+
+**One-way doors** — Numbered list. If none found, say "None identified."
+
+**Findings** — Numbered list of problems found. Each must:
+1. Name the specific file and code pattern
+2. Explain the failure mode or risk
+3. Rate severity: [critical], [warning], or [minor]
+
+**Missing** — What you expected to see in this PR but did not. Be specific.
+
+**Verdict** — Ship it, ship with fixes, or block. One sentence with reasoning.
+
+Be blunt. If the PR looks clean, say so in two sentences and move on. Do not
+manufacture concerns to fill space. But do not go easy either — assume the author
+is competent and can handle direct feedback.
+
+Keep the total review under 700 words.

--- a/.github/scripts/blind_review.py
+++ b/.github/scripts/blind_review.py
@@ -1,0 +1,264 @@
+"""Blind PR review — posts an LLM review using only docs + diff as context."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+MAX_DIFF_LINES = 10_000
+WEBSITE_URL = "https://synix.dev"
+LLM_TIMEOUT = 120  # seconds
+
+CLAUDE_MODEL = "claude-opus-4-6"
+OPENAI_MODEL = "o3"
+
+PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
+
+# ---------------------------------------------------------------------------
+# Context gathering
+# ---------------------------------------------------------------------------
+
+
+def fetch_diff(repo: str, pr_number: str, token: str) -> str:
+    """Fetch PR diff via GitHub API."""
+    url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github.v3.diff",
+    }
+    resp = requests.get(url, headers=headers, timeout=30)
+    resp.raise_for_status()
+    return resp.text
+
+
+def fetch_website(url: str) -> str:
+    """Fetch website content as plain text. Best-effort."""
+    try:
+        resp = requests.get(url, timeout=15, headers={"User-Agent": "synix-blind-review"})
+        resp.raise_for_status()
+        text = re.sub(r"<script[^>]*>.*?</script>", "", resp.text, flags=re.DOTALL)
+        text = re.sub(r"<style[^>]*>.*?</style>", "", text, flags=re.DOTALL)
+        text = re.sub(r"<[^>]+>", " ", text)
+        text = re.sub(r"\s+", " ", text).strip()
+        return text[:5000]
+    except Exception:
+        return "(website content unavailable)"
+
+
+def truncate_diff(diff: str) -> tuple[str, int, int]:
+    """Truncate diff to MAX_DIFF_LINES. Returns (diff, shown_lines, total_lines)."""
+    lines = diff.splitlines()
+    total = len(lines)
+    if total <= MAX_DIFF_LINES:
+        return diff, total, total
+    truncated = "\n".join(lines[:MAX_DIFF_LINES])
+    truncated += f"\n\n... [diff truncated: showing first {MAX_DIFF_LINES:,} of {total:,} lines]"
+    return truncated, MAX_DIFF_LINES, total
+
+
+def load_prompt(provider: str) -> str:
+    """Load the review prompt for the given provider."""
+    prompt_file = PROMPTS_DIR / f"{provider}_review.md"
+    return prompt_file.read_text()
+
+
+def read_file(name: str) -> str:
+    """Read a file from the workspace."""
+    workspace = Path(os.environ.get("GITHUB_WORKSPACE", "."))
+    path = workspace / name
+    if path.exists():
+        return path.read_text()
+    return f"({name} not found)"
+
+
+# ---------------------------------------------------------------------------
+# LLM calls
+# ---------------------------------------------------------------------------
+
+
+def build_user_message(readme: str, design_doc: str, website: str, diff: str) -> str:
+    """Compose the user message with all four context sections."""
+    return f"""## README.md
+
+{readme}
+
+---
+
+## DESIGN.md
+
+{design_doc}
+
+---
+
+## Website content (synix.dev)
+
+{website}
+
+---
+
+## PR Diff
+
+```diff
+{diff}
+```"""
+
+
+def review_claude(system_prompt: str, user_message: str) -> tuple[str, str]:
+    """Call Claude API with extended thinking. Returns (review_text, model_name)."""
+    import anthropic
+
+    client = anthropic.Anthropic()
+    response = client.messages.create(
+        model=CLAUDE_MODEL,
+        max_tokens=16000,
+        temperature=1,  # required for extended thinking
+        thinking={
+            "type": "enabled",
+            "budget_tokens": 10000,
+        },
+        system=system_prompt,
+        messages=[{"role": "user", "content": user_message}],
+    )
+    # Extract the text block (skip thinking blocks)
+    for block in response.content:
+        if block.type == "text":
+            return block.text, CLAUDE_MODEL
+    return "(no text in response)", CLAUDE_MODEL
+
+
+def review_openai(system_prompt: str, user_message: str) -> tuple[str, str]:
+    """Call OpenAI API with o3. Returns (review_text, model_name)."""
+    import openai
+
+    client = openai.OpenAI()
+    response = client.chat.completions.create(
+        model=OPENAI_MODEL,
+        messages=[
+            {"role": "developer", "content": system_prompt},
+            {"role": "user", "content": user_message},
+        ],
+    )
+    return response.choices[0].message.content, OPENAI_MODEL
+
+
+# ---------------------------------------------------------------------------
+# GitHub interaction
+# ---------------------------------------------------------------------------
+
+
+def post_comment(repo: str, pr_number: str, token: str, body: str) -> None:
+    """Post a comment on the PR via GitHub API."""
+    url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+    resp = requests.post(url, headers=headers, json={"body": body}, timeout=15)
+    resp.raise_for_status()
+
+
+def format_comment(
+    review: str,
+    provider: str,
+    model: str,
+    diff_shown: int,
+    diff_total: int,
+    prompt_file: str,
+) -> str:
+    """Format the review as a PR comment."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    if provider == "claude":
+        header = f"**Architectural Review** — Claude Opus | Blind review (docs + diff only)"
+    else:
+        header = f"**Red Team Review** — OpenAI o3 | Adversarial review (docs + diff only)"
+
+    diff_note = f"{diff_shown:,} lines"
+    if diff_shown < diff_total:
+        diff_note += f" (of {diff_total:,} total — truncated)"
+
+    return f"""> [!NOTE]
+> {header}
+
+{review}
+
+<details>
+<summary>Review parameters</summary>
+
+- **Model**: `{model}`
+- **Context**: README.md, DESIGN.md, synix.dev, PR diff
+- **Diff size**: {diff_note}
+- **Prompt**: `{prompt_file}`
+- **Timestamp**: {timestamp}
+
+</details>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    provider = os.environ["PROVIDER"]  # "claude" or "openai"
+    token = os.environ["GITHUB_TOKEN"]
+    pr_number = os.environ["PR_NUMBER"]
+    repo = os.environ["REPO"]
+
+    # 1. Gather context
+    print(f"Fetching diff for {repo}#{pr_number}...")
+    raw_diff = fetch_diff(repo, pr_number, token)
+    diff, diff_shown, diff_total = truncate_diff(raw_diff)
+    print(f"Diff: {diff_total:,} lines ({diff_shown:,} shown)")
+
+    readme = read_file("README.md")
+    design_doc = read_file("docs/DESIGN.md")
+
+    print("Fetching website content...")
+    website = fetch_website(WEBSITE_URL)
+
+    # 2. Build prompt and call LLM
+    system_prompt = load_prompt(provider)
+    user_message = build_user_message(readme, design_doc, website, diff)
+    prompt_file = f".github/prompts/{provider}_review.md"
+
+    print(f"Calling {provider} API ({CLAUDE_MODEL if provider == 'claude' else OPENAI_MODEL})...")
+    try:
+        if provider == "claude":
+            review, model = review_claude(system_prompt, user_message)
+        elif provider == "openai":
+            review, model = review_openai(system_prompt, user_message)
+        else:
+            print(f"Unknown provider: {provider}", file=sys.stderr)
+            sys.exit(1)
+    except Exception as exc:
+        error_type = type(exc).__name__
+        fail_body = (
+            f"> [!WARNING]\n"
+            f"> **AI Review failed** — {provider} | `{error_type}`\n\n"
+            f"The {provider} blind review could not be completed. "
+            f"This does not affect the PR.\n"
+        )
+        print(f"LLM call failed ({error_type}): {exc}", file=sys.stderr)
+        post_comment(repo, pr_number, token, fail_body)
+        sys.exit(0)  # don't red-X the PR
+
+    # 3. Post review comment
+    print(f"Posting review ({len(review)} chars)...")
+    body = format_comment(review, provider, model, diff_shown, diff_total, prompt_file)
+    post_comment(repo, pr_number, token, body)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/blind-review.yml
+++ b/.github/workflows/blind-review.yml
@@ -1,0 +1,89 @@
+name: Blind PR Review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+env:
+  APPROVED_CONTRIBUTORS: '["marklubin"]'
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      approved: ${{ steps.check.outputs.approved }}
+    steps:
+      - id: check
+        run: |
+          ACTOR="${{ github.actor }}"
+          if echo '${{ env.APPROVED_CONTRIBUTORS }}' | jq -e ". | index(\"$ACTOR\")" > /dev/null 2>&1; then
+            echo "approved=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Blind review approved for $ACTOR"
+          else
+            echo "approved=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping blind review — $ACTOR is not in approved list"
+          fi
+
+  review-claude:
+    needs: gate
+    if: needs.gate.outputs.approved == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: |
+            .github/scripts/blind_review.py
+            .github/prompts/claude_review.md
+            .github/prompts/openai_review.md
+            README.md
+            docs/DESIGN.md
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install anthropic requests
+
+      - run: python .github/scripts/blind_review.py
+        env:
+          PROVIDER: claude
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+
+  review-openai:
+    needs: gate
+    if: needs.gate.outputs.approved == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: |
+            .github/scripts/blind_review.py
+            .github/prompts/claude_review.md
+            .github/prompts/openai_review.md
+            README.md
+            docs/DESIGN.md
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install openai requests
+
+      - run: python .github/scripts/blind_review.py
+        env:
+          PROVIDER: openai
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Adds an automated blind PR review workflow that runs on every PR from approved contributors. Two LLMs review in parallel with zero codebase context — only the README, DESIGN.md, synix.dev website, and the diff.

- **Claude Opus** — architectural reviewer checking vision alignment, legibility, correctness, test coverage, ergonomics, and scale
- **OpenAI o3** — adversarial red-teamer hunting one-way doors, design flaws, missing tests, hidden complexity, and reliability risks

Gated to approved contributors via a YAML array in the workflow (`APPROVED_CONTRIBUTORS`). Random PRs from unknown authors are skipped before any API calls.

## Files

- `.github/workflows/blind-review.yml` — workflow with gate + two parallel review jobs
- `.github/scripts/blind_review.py` — review script (fetches diff, docs, calls LLM, posts comment)
- `.github/prompts/claude_review.md` — constructive architectural reviewer prompt
- `.github/prompts/openai_review.md` — adversarial red-team reviewer prompt

## Security

- Uses `pull_request_target` for secret access but only checks out base branch via sparse-checkout
- PR diff fetched via GitHub API as data — never executed
- Gate job prevents unapproved authors from triggering any API calls

## Manual setup required

- [ ] Add `OPENAI_API_KEY` as a GitHub repository secret
- [ ] Verify `ANTHROPIC_API_KEY` exists as a repo-level secret

## Test plan

- [ ] This PR should trigger the workflow on itself
- [ ] Verify gate job passes for marklubin
- [ ] Verify both review comments appear on this PR