### PR TITLE
Add REST search and buckets endpoints

### DIFF
--- a/src/synix/server/api.py
+++ b/src/synix/server/api.py
@@ -9,7 +9,13 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, PlainTextResponse, Response
 from starlette.routing import Route
 
-from synix.server.mcp_tools import _atomic_write, _current_release, _resolve_bucket_dir, _safe_filename
+from synix.server.mcp_tools import (
+    _atomic_write,
+    _current_release,
+    _require_config,
+    _resolve_bucket_dir,
+    _safe_filename,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -71,8 +77,70 @@ async def ingest_to_bucket(request: Request) -> Response:
         return JSONResponse({"error": str(exc)}, status_code=500)
 
 
+async def search_api(request: Request) -> Response:
+    """GET /api/v1/search?q=...&layers=...&limit=... — search the knowledge base."""
+    query = request.query_params.get("q", "")
+    if not query:
+        return JSONResponse({"error": "Query parameter 'q' is required"}, status_code=400)
+
+    limit = int(request.query_params.get("limit", "10"))
+    layers_param = request.query_params.get("layers")
+
+    logger.info("REST search: q=%r layers=%s limit=%d", query, layers_param, limit)
+
+    try:
+        rel = _current_release()
+    except (ValueError, Exception) as exc:
+        return JSONResponse({"error": str(exc)}, status_code=503)
+
+    try:
+        layers_list = None
+        if layers_param:
+            layers_list = [l.strip() for l in layers_param.split(",") if l.strip()]
+
+        results = rel.search(query, mode="keyword", limit=limit, layers=layers_list)
+        logger.info("REST search: %d results for %r", len(results), query)
+
+        return JSONResponse({
+            "query": query,
+            "count": len(results),
+            "results": [
+                {
+                    "label": r.label,
+                    "layer": r.layer,
+                    "score": round(r.score, 3),
+                    "content": r.content[:500],
+                }
+                for r in results
+            ],
+        })
+    except Exception as exc:
+        logger.error("REST search failed: %s", exc)
+        return JSONResponse({"error": str(exc)}, status_code=500)
+
+
+async def list_buckets_api(request: Request) -> Response:
+    """GET /api/v1/buckets — list configured buckets."""
+    try:
+        config = _require_config()
+        buckets = [
+            {
+                "name": b.name,
+                "dir": b.dir,
+                "patterns": b.patterns,
+                "description": b.description,
+            }
+            for b in config.buckets
+        ]
+        return JSONResponse({"buckets": buckets})
+    except Exception as exc:
+        return JSONResponse({"error": str(exc)}, status_code=500)
+
+
 api_routes = [
     Route("/api/v1/health", health, methods=["GET"]),
     Route("/api/v1/flat-file/{name:path}", get_flat_file, methods=["GET"]),
     Route("/api/v1/ingest/{bucket}", ingest_to_bucket, methods=["POST"]),
+    Route("/api/v1/search", search_api, methods=["GET"]),
+    Route("/api/v1/buckets", list_buckets_api, methods=["GET"]),
 ]

--- a/tests/e2e/server/test_server_e2e.py
+++ b/tests/e2e/server/test_server_e2e.py
@@ -26,6 +26,18 @@ class TestHealthEndpoint:
 # ---------------------------------------------------------------------------
 
 
+class TestBucketsEndpoint:
+    def test_list_buckets(self, client):
+        resp = client.get("/api/v1/buckets")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["buckets"]) == 3
+        names = [b["name"] for b in data["buckets"]]
+        assert "documents" in names
+        assert "sessions" in names
+        assert "reports" in names
+
+
 class TestIngestEndpoint:
     def test_ingest_to_documents_bucket(self, client, server_project):
         project_dir, config = server_project
@@ -140,14 +152,24 @@ class TestIngestEndpoint:
 
 
 class TestSearchEndpoint:
-    def test_search_finds_ingested_content(self, built_server):
+    def test_search_returns_results(self, built_server):
         client, _, _ = built_server
-        resp = client.get("/api/v1/health")
+        resp = client.get("/api/v1/search?q=summary")
         assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] > 0
+        assert len(data["results"]) > 0
+        assert "label" in data["results"][0]
+        assert "score" in data["results"][0]
 
-        # Search for content we ingested
-        # Note: search is via MCP tools, not REST. But we can verify
-        # the flat file endpoint works after build.
+    def test_search_empty_query_400(self, client):
+        resp = client.get("/api/v1/search")
+        assert resp.status_code == 400
+
+    def test_search_no_build_returns_error(self, client):
+        resp = client.get("/api/v1/search?q=test")
+        assert resp.status_code in (500, 503)
+        assert "error" in resp.json()
 
     def test_flat_file_returns_context(self, built_server):
         client, project_dir, _ = built_server


### PR DESCRIPTION
## Summary

Adds two REST endpoints to the knowledge server so the mcp-router on oxnard
can proxy all 4 operations (ingest, search, get_context, list_buckets) via
simple HTTP without MCP-to-MCP overhead.

- `GET /api/v1/search?q=...&layers=...&limit=...` — search the knowledge base
- `GET /api/v1/buckets` — list configured buckets

## Test plan

- [x] 4 new e2e tests (search results, empty query, no-build error, bucket list)
- [x] 28 total e2e server tests pass